### PR TITLE
switched object comparison (directory selection)

### DIFF
--- a/src/main/java/org/terasology/launcher/gui/GuiUtils.java
+++ b/src/main/java/org/terasology/launcher/gui/GuiUtils.java
@@ -47,7 +47,7 @@ public final class GuiUtils {
 
         final File selected = directoryChooser.showDialog(parentWindow);
         // directory proposal needs to be deleted if the user chose a different one
-        if (!selected.equals(directory)) {
+        if (!directory.equals(selected)) {
             directory.delete();
         }
         return selected;


### PR DESCRIPTION
prevents NPE when no directory was selected.
