### PR TITLE
Skip non-existing builds when collecting build numbers.

### DIFF
--- a/src/main/java/org/terasology/launcher/game/TerasologyGameVersions.java
+++ b/src/main/java/org/terasology/launcher/game/TerasologyGameVersions.java
@@ -183,9 +183,16 @@ public final class TerasologyGameVersions {
             if ((lastSuccessfulBuildNumber != null) && (lastSuccessfulBuildNumber >= job.getMinBuildNumber())) {
                 buildNumbers.add(lastSuccessfulBuildNumber);
                 // add previous build numbers
-                final int prevBuildNumber = Math.max(job.getMinBuildNumber(), lastSuccessfulBuildNumber - job.getPrevBuildNumbers());
-                for (int buildNumber = prevBuildNumber; buildNumber < lastSuccessfulBuildNumber; buildNumber++) {
-                    buildNumbers.add(buildNumber);
+                for (int buildNumber = lastSuccessfulBuildNumber - 1; ((buildNumbers.size() <= job.getPrevBuildNumbers()) && buildNumber > job.getMinBuildNumber());
+                     buildNumber--) {
+                    try {
+                        // Skip unavailable builds
+                        DownloadUtils.loadJobResultJenkins(job.name(), buildNumber);
+                        buildNumbers.add(buildNumber);
+                    } catch (DownloadException e) {
+                        logger.info("Cannot find build number '{}' for job '{}'.", buildNumber, job);
+                    }
+
                 }
             }
         }
@@ -465,7 +472,12 @@ public final class TerasologyGameVersions {
 
     private List<TerasologyGameVersion> createList(Integer lastBuildNumber, GameJob job, SortedMap<Integer, TerasologyGameVersion> gameVersionMap) {
         final List<TerasologyGameVersion> gameVersionList = new ArrayList<>();
-        gameVersionList.addAll(gameVersionMap.values());
+        // add only available builds
+        for (TerasologyGameVersion version : gameVersionMap.values()) {
+            if (version.getSuccessful() != null) {
+                gameVersionList.add(version);
+            }
+        }
 
         final TerasologyGameVersion latestGameVersion = new TerasologyGameVersion();
         latestGameVersion.setLatest(true);


### PR DESCRIPTION
This should collect the build numbers to present to the user (up to the job specific number of previous builds), but skipping non-existing builds (different from failed builds!). This issue became obvious with the latest server crash.

@mkalb I'd appreciate a short review. Did I miss something?
