### PR TITLE
Properly handle exceptions in the init task.

### DIFF
--- a/src/main/java/org/terasology/launcher/util/LauncherStartFailedException.java
+++ b/src/main/java/org/terasology/launcher/util/LauncherStartFailedException.java
@@ -16,10 +16,14 @@
 
 package org.terasology.launcher.util;
 
-public class LauncherStartFailedException extends RuntimeException {
+public class LauncherStartFailedException extends Exception {
 
     private static final long serialVersionUID = -6096111978556806948L;
 
     public LauncherStartFailedException() {
+    }
+
+    public LauncherStartFailedException(String message) {
+        super(message);
     }
 }


### PR DESCRIPTION
- exceptions are now get caught and `null` is returned as configuration
- launcher's start method checks for null before displaying the main stage
