### PR TITLE
Added a fall-back for loading FXML files.

### DIFF
--- a/src/main/java/org/terasology/launcher/TerasologyLauncher.java
+++ b/src/main/java/org/terasology/launcher/TerasologyLauncher.java
@@ -133,9 +133,17 @@ public final class TerasologyLauncher extends Application {
         mainStage = new Stage(StageStyle.DECORATED);
 
         // launcher frame
-        final FXMLLoader fxmlLoader = new FXMLLoader(BundleUtils.getFXMLUrl("application"), ResourceBundle.getBundle("org.terasology.launcher.bundle.LabelsBundle",
-            Languages.getCurrentLocale()));
-        final Parent root = (Parent) fxmlLoader.load();
+        FXMLLoader fxmlLoader;
+        Parent root;
+        /* Fall back to default language if loading the FXML file files with the current locale */
+        try {
+            fxmlLoader = BundleUtils.getFXMLLoader("application");
+            root = (Parent) fxmlLoader.load();
+        } catch (IOException e) {
+            fxmlLoader = BundleUtils.getFXMLLoader("application");
+            fxmlLoader.setResources(ResourceBundle.getBundle("org.terasology.launcher.bundle.LabelsBundle", Languages.DEFAULT_LOCALE));
+            root = (Parent) fxmlLoader.load();
+        }
         final ApplicationController controller = fxmlLoader.getController();
         controller.initialize(launcherConfiguration.getLauncherDirectory(), launcherConfiguration.getDownloadDirectory(), launcherConfiguration.getTempDirectory(),
             launcherConfiguration.getLauncherSettings(), launcherConfiguration.getGameVersions(), mainStage);

--- a/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
@@ -167,9 +167,18 @@ public class ApplicationController {
             Stage settingsStage = new Stage(StageStyle.UNDECORATED);
             settingsStage.initModality(Modality.APPLICATION_MODAL);
 
-            final FXMLLoader fxmlLoader = new FXMLLoader(BundleUtils.getFXMLUrl("settings"), ResourceBundle.getBundle("org.terasology.launcher.bundle.LabelsBundle",
-                Languages.getCurrentLocale()));
-            Parent root = (Parent) fxmlLoader.load();
+            FXMLLoader fxmlLoader;
+            Parent root;
+            /* Fall back to default language if loading the FXML file files with the current locale */
+            try {
+                fxmlLoader = BundleUtils.getFXMLLoader("settings");
+                root = (Parent) fxmlLoader.load();
+            } catch (IOException e) {
+                fxmlLoader = BundleUtils.getFXMLLoader("settings");
+                fxmlLoader.setResources(ResourceBundle.getBundle("org.terasology.launcher.bundle.LabelsBundle", Languages.DEFAULT_LOCALE));
+                root = (Parent) fxmlLoader.load();
+            }
+
             final SettingsController settingsController = fxmlLoader.getController();
             settingsController.initialize(launcherDirectory, downloadDirectory, launcherSettings, gameVersions, settingsStage);
 

--- a/src/main/java/org/terasology/launcher/util/BundleUtils.java
+++ b/src/main/java/org/terasology/launcher/util/BundleUtils.java
@@ -16,6 +16,7 @@
 
 package org.terasology.launcher.util;
 
+import javafx.fxml.FXMLLoader;
 import javafx.scene.image.Image;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,6 +106,10 @@ public final class BundleUtils {
     public static Image getFxImage(String key) throws MissingResourceException {
         final String imagePath = ResourceBundle.getBundle(IMAGE_BUNDLE, Languages.getCurrentLocale()).getString(key);
         return new Image(BundleUtils.class.getResource(imagePath).toExternalForm());
+    }
+
+    public static FXMLLoader getFXMLLoader(String key) {
+        return new FXMLLoader(getFXMLUrl(key), ResourceBundle.getBundle("org.terasology.launcher.bundle.LabelsBundle", Languages.getCurrentLocale()));
     }
 
     public static URL getFXMLUrl(String key) {


### PR DESCRIPTION
- prevents the launcher to crash whenever a label translation is missing (for labels directly used within the FXML file)
