### PR TITLE
Enable use of the system proxy.

### DIFF
--- a/src/main/java/org/terasology/launcher/TerasologyLauncher.java
+++ b/src/main/java/org/terasology/launcher/TerasologyLauncher.java
@@ -92,6 +92,7 @@ public final class TerasologyLauncher extends Application {
         logger.info("TerasologyLauncher is starting");
         logSystemInformation();
 
+        initProxy();
         initLanguage();
 
         final Task<LauncherConfiguration> launcherInitTask = new LauncherInitTask(initialStage);
@@ -114,6 +115,14 @@ public final class TerasologyLauncher extends Application {
             }
         });
         initThread.start();
+    }
+
+    /**
+     * Sets the system property as advised by the following website:
+     * http://docs.oracle.com/javase/7/docs/technotes/guides/net/proxies.html
+     */
+    private void initProxy() {
+        System.setProperty("java.net.useSystemProxies", "true");
     }
 
     /**


### PR DESCRIPTION
Java is capable of using the standard system proxy set in Gnome and the Windows control panel.

See here:
http://docs.oracle.com/javase/7/docs/technotes/guides/net/proxies.html

I added the necessary system property to the startup.