### PR TITLE
First pass toward launcher working with changed zip structure + Omega support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Terasology Launcher - ChangeLog
 ===============================
 
+## 2.0.0 (2015-04-26
+* Launcher now retrieves the "Omega" zip which is base Terasology + the modules in the standard lineup
+* Structure of Terasology.zip changed, Terasology.jar is now inside the "libs" directory
+
 ## 1.4.2 (2014-10-11)
 * Fix for OS X when selecting game and launcher directory at first start
 * Small GUI change (removed "Mods" link)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Terasology Launcher - ChangeLog
 ## 2.0.0 (2015-04-26
 * Launcher now retrieves the "Omega" zip which is base Terasology + the modules in the standard lineup
 * Structure of Terasology.zip changed, Terasology.jar is now inside the "libs" directory
+* Substantial rework of how game and engine jars are detected and used 
+* Much much more to be added
 
 ## 1.4.2 (2014-10-11)
 * Fix for OS X when selecting game and launcher directory at first start

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Terasology and related projects are developed by a group of software enthusiast 
 
 Usage
 -----
-*Terasology Launcher* requires Java 7.
+*Terasology Launcher* requires Java 7 or higher.
 
 1. Download and extract the ZIP file
    * [official releases][Download GitHub Releases] (recommended)

--- a/src/main/java/org/terasology/launcher/LauncherSettings.java
+++ b/src/main/java/org/terasology/launcher/LauncherSettings.java
@@ -42,6 +42,9 @@ import java.util.Properties;
  */
 public final class LauncherSettings implements GameSettings {
 
+    public static final String USER_JAVA_PARAMETERS_DEFAULT = "-XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:MaxGCPauseMillis=20 -XX:ParallelGCThreads=10";
+    public static final String USER_GAME_PARAMETERS_DEFAULT = "";
+
     private static final Logger logger = LoggerFactory.getLogger(LauncherSettings.class);
 
     private static final String LAUNCHER_SETTINGS_FILE_NAME = "TerasologyLauncherSettings.properties";
@@ -54,8 +57,6 @@ public final class LauncherSettings implements GameSettings {
     private static final boolean SEARCH_FOR_LAUNCHER_UPDATES_DEFAULT = true;
     private static final boolean CLOSE_LAUNCHER_AFTER_GAME_START_DEFAULT = true;
     private static final boolean SAVE_DOWNLOADED_FILES_DEFAULT = false;
-    public static final String USER_JAVA_PARAMETERS_DEFAULT = "-XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:MaxGCPauseMillis=20 -XX:ParallelGCThreads=10";
-    public static final String USER_GAME_PARAMETERS_DEFAULT = "";
 
     private static final String PROPERTY_LOCALE = "locale";
     private static final String PROPERTY_JOB = "job";

--- a/src/main/java/org/terasology/launcher/game/GameDownloader.java
+++ b/src/main/java/org/terasology/launcher/game/GameDownloader.java
@@ -57,7 +57,18 @@ public final class GameDownloader {
         if (downloadZipFile.exists() && (!downloadZipFile.isFile() || !downloadZipFile.delete())) {
             throw new IOException("Could not delete file! " + downloadZipFile);
         }
-        downloadURL = DownloadUtils.createFileDownloadUrlJenkins(jobName, buildNumber, DownloadUtils.FILE_TERASOLOGY_GAME_ZIP);
+
+        // If we have a matching Omega distribution for this game version then fetch that zip file instead
+        if (gameVersion.getOmegaNumber() != null) {
+            logger.info("Omega distribution {} is available for that engine build, downloading it", gameVersion.getOmegaNumber());
+            downloadURL = DownloadUtils.createFileDownloadUrlJenkins(gameVersion.getJob().getOmegaJobName(),
+                    gameVersion.getOmegaNumber(), DownloadUtils.FILE_TERASOLOGY_OMEGA_ZIP);
+        } else {
+            logger.warn("Engine build {} has no Omega zip available! Falling back to main zip without extra modules", buildNumber);
+            downloadURL = DownloadUtils.createFileDownloadUrlJenkins(jobName, buildNumber, DownloadUtils.FILE_TERASOLOGY_GAME_ZIP);
+        }
+        logger.info("The download URL is {}", downloadURL);
+
         final File gameJobDirectory = new File(new File(gameParentDirectory, gameVersion.getJob().getInstallationDirectory()), jobName);
         DirectoryUtils.checkDirectory(gameJobDirectory);
         gameDirectory = new File(gameJobDirectory, buildNumber.toString());

--- a/src/main/java/org/terasology/launcher/game/GameJob.java
+++ b/src/main/java/org/terasology/launcher/game/GameJob.java
@@ -21,9 +21,9 @@ package org.terasology.launcher.game;
  */
 public enum GameJob {
 
-    TerasologyStable("master", "DistroOmegaRelease", 30, 5, true, false, "STABLE", "infoHeader1_TerasologyStable", "settings_game_buildType_TerasologyStable"),
+    TerasologyStable("master", "DistroOmegaRelease", 49, 5, true, false, "STABLE", "infoHeader1_TerasologyStable", "settings_game_buildType_TerasologyStable"),
 
-    Terasology("develop", "DistroOmega", 995, 40, false, false, "NIGHTLY", "infoHeader1_Terasology", "settings_game_buildType_Terasology");
+    Terasology("develop", "DistroOmega", 1355, 40, false, false, "NIGHTLY", "infoHeader1_Terasology", "settings_game_buildType_Terasology");
 
     private final String gitBranch;
     private final String omegaJobName;

--- a/src/main/java/org/terasology/launcher/game/GameJob.java
+++ b/src/main/java/org/terasology/launcher/game/GameJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MovingBlocks
+ * Copyright 2015 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,17 @@
 
 package org.terasology.launcher.game;
 
+/**
+ * Enum for available job lines from Jenkins we track.
+ */
 public enum GameJob {
 
-    TerasologyStable("master", 30, 5, true, false, "STABLE", "infoHeader1_TerasologyStable", "settings_game_buildType_TerasologyStable"),
+    TerasologyStable("master", "DistroOmegaRelease", 30, 5, true, false, "STABLE", "infoHeader1_TerasologyStable", "settings_game_buildType_TerasologyStable"),
 
-    TerasologyLegacy("legacy", 1, 0, true, true, "STABLE", "infoHeader1_TerasologyLegacy", "settings_game_buildType_TerasologyLegacy"),
-
-    Terasology("develop", 995, 9, false, false, "NIGHTLY", "infoHeader1_Terasology", "settings_game_buildType_Terasology"),
-
-    TerasologyMulti("multiplayer", 1, 0, false, true, "NIGHTLY", "infoHeader1_TerasologyMulti", "settings_game_buildType_TerasologyMulti");
+    Terasology("develop", "DistroOmega", 995, 40, false, false, "NIGHTLY", "infoHeader1_Terasology", "settings_game_buildType_Terasology");
 
     private final String gitBranch;
+    private final String omegaJobName;
     private final int minBuildNumber;
     private final int prevBuildNumbers;
     private final boolean stable;
@@ -35,9 +35,10 @@ public enum GameJob {
     private final String infoMessageKey;
     private final String settingsKey;
 
-    private GameJob(String gitBranch, int minBuildNumber, int prevBuildNumbers, boolean stable, boolean onlyInstalled, String installationDirectory, String infoMessageKey,
+    GameJob(String gitBranch, String omegaJob, int minBuildNumber, int prevBuildNumbers, boolean stable, boolean onlyInstalled, String installationDirectory, String infoMessageKey,
                     String settingsKey) {
         this.gitBranch = gitBranch;
+        this.omegaJobName = omegaJob;
         this.minBuildNumber = minBuildNumber;
         this.prevBuildNumbers = prevBuildNumbers;
         this.stable = stable;
@@ -49,6 +50,10 @@ public enum GameJob {
 
     public final String getGitBranch() {
         return gitBranch;
+    }
+
+    public final String getOmegaJobName() {
+        return omegaJobName;
     }
 
     public int getMinBuildNumber() {

--- a/src/main/java/org/terasology/launcher/game/GameStarter.java
+++ b/src/main/java/org/terasology/launcher/game/GameStarter.java
@@ -76,7 +76,7 @@ public final class GameStarter {
         processParameters.add("java");
         processParameters.addAll(javaParameters);
         processParameters.add("-jar");
-        processParameters.add("libs/" + gameVersion.getGameJar().getName());
+        processParameters.add(gameVersion.getGameJar().getName());
         processParameters.add("-homedir=" + gameDataDirectory.getPath());
         processParameters.addAll(gameParameters);
 

--- a/src/main/java/org/terasology/launcher/game/GameStarter.java
+++ b/src/main/java/org/terasology/launcher/game/GameStarter.java
@@ -76,7 +76,7 @@ public final class GameStarter {
         processParameters.add("java");
         processParameters.addAll(javaParameters);
         processParameters.add("-jar");
-        processParameters.add(gameVersion.getGameJar().getName());
+        processParameters.add("libs/" + gameVersion.getGameJar().getName());
         processParameters.add("-homedir=" + gameDataDirectory.getPath());
         processParameters.addAll(gameParameters);
 

--- a/src/main/java/org/terasology/launcher/game/TerasologyGameVersion.java
+++ b/src/main/java/org/terasology/launcher/game/TerasologyGameVersion.java
@@ -29,31 +29,31 @@ public final class TerasologyGameVersion implements Serializable {
 
     private static final long serialVersionUID = 4L;
 
-    /** Build number for the engine job in Jenkins (bare engine + Core) */
+    /** Build number for the engine job in Jenkins (bare engine + Core). */
     private Integer buildNumber;
 
-    /** Build number for the Omega distribution job in Jenkins (includes extra modules) */
+    /** Build number for the Omega distribution job in Jenkins (includes extra modules). */
     private Integer omegaNumber;
 
-    /** Which job line in Jenkins this build is part of */
+    /** Which job line in Jenkins this build is part of. */
     private GameJob job;
 
-    /** Detailed version information for the engine */
+    /** Detailed version information for the engine. */
     private TerasologyGameVersionInfo gameVersionInfo;
 
-    /** What path the game has been installed to locally */
+    /** What path the game has been installed to locally. */
     private transient File installationPath;
 
-    /** Direct reference to the main game jar */
+    /** Direct reference to the main game jar. */
     private transient File gameJar;
 
-    /** Changes for this version */
+    /** Changes for this version. */
     private List<String> changeLog;
 
-    /** Success status from Jenkins */
+    /** Success status from Jenkins. */
     private Boolean successful;
 
-    /** Whether or not this instance is the very latest in the job line or not */
+    /** Whether or not this instance is the very latest in the job line or not. */
     private boolean latest;
 
     public TerasologyGameVersion() {
@@ -90,7 +90,7 @@ public final class TerasologyGameVersion implements Serializable {
     }
 
     public Integer getOmegaNumber() {
-        return buildNumber;
+        return omegaNumber;
     }
 
     void setOmegaNumber(Integer omegaNumber) {
@@ -155,6 +155,7 @@ public final class TerasologyGameVersion implements Serializable {
 
     @Override
     public String toString() {
-        return this.getClass().getName() + "[" + job + ", " + buildNumber + ", latest=" + latest + ", successful=" + successful + ", installed=" + isInstalled() + "]";
+        return this.getClass().getName() + "[" + job + ", engine=" + buildNumber + ", omega=" + omegaNumber + ", latest="
+                + latest + ", successful=" + successful + ", installed=" + isInstalled() + "]";
     }
 }

--- a/src/main/java/org/terasology/launcher/game/TerasologyGameVersion.java
+++ b/src/main/java/org/terasology/launcher/game/TerasologyGameVersion.java
@@ -44,7 +44,7 @@ public final class TerasologyGameVersion implements Serializable {
     /** What path the game has been installed to locally. */
     private transient File installationPath;
 
-    /** Direct reference to the main game jar. */
+    /** Direct reference to the Terasology game jar. */
     private transient File gameJar;
 
     /** Changes for this version. */

--- a/src/main/java/org/terasology/launcher/game/TerasologyGameVersion.java
+++ b/src/main/java/org/terasology/launcher/game/TerasologyGameVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2015 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,20 +20,40 @@ import java.io.File;
 import java.io.Serializable;
 import java.util.List;
 
+/**
+ * Contains general information about a single retrieved build for Terasology.
+ */
 public final class TerasologyGameVersion implements Serializable {
 
     public static final int BUILD_VERSION_LATEST = -1;
 
-    private static final long serialVersionUID = 3L;
+    private static final long serialVersionUID = 4L;
 
+    /** Build number for the engine job in Jenkins (bare engine + Core) */
     private Integer buildNumber;
+
+    /** Build number for the Omega distribution job in Jenkins (includes extra modules) */
+    private Integer omegaNumber;
+
+    /** Which job line in Jenkins this build is part of */
     private GameJob job;
+
+    /** Detailed version information for the engine */
     private TerasologyGameVersionInfo gameVersionInfo;
+
+    /** What path the game has been installed to locally */
     private transient File installationPath;
+
+    /** Direct reference to the main game jar */
     private transient File gameJar;
+
+    /** Changes for this version */
     private List<String> changeLog;
+
+    /** Success status from Jenkins */
     private Boolean successful;
 
+    /** Whether or not this instance is the very latest in the job line or not */
     private boolean latest;
 
     public TerasologyGameVersion() {
@@ -41,6 +61,7 @@ public final class TerasologyGameVersion implements Serializable {
 
     public void copyTo(TerasologyGameVersion gameVersion) {
         gameVersion.setBuildNumber(buildNumber);
+        gameVersion.setOmegaNumber(omegaNumber);
         gameVersion.setJob(job);
         gameVersion.setGameVersionInfo(gameVersionInfo);
         gameVersion.setInstallationPath(installationPath);
@@ -66,6 +87,14 @@ public final class TerasologyGameVersion implements Serializable {
 
     void setBuildNumber(Integer buildNumber) {
         this.buildNumber = buildNumber;
+    }
+
+    public Integer getOmegaNumber() {
+        return buildNumber;
+    }
+
+    void setOmegaNumber(Integer omegaNumber) {
+        this.omegaNumber = omegaNumber;
     }
 
     public GameJob getJob() {

--- a/src/main/java/org/terasology/launcher/game/TerasologyGameVersionInfo.java
+++ b/src/main/java/org/terasology/launcher/game/TerasologyGameVersionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MovingBlocks
+ * Copyright 2015 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,9 @@ import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+/***
+ * Contains version data for a single instance of a Terasology engine build, parsed out of the main jar.
+ */
 public final class TerasologyGameVersionInfo implements Serializable {
 
     private static final long serialVersionUID = 4L;

--- a/src/main/java/org/terasology/launcher/game/TerasologyGameVersions.java
+++ b/src/main/java/org/terasology/launcher/game/TerasologyGameVersions.java
@@ -112,7 +112,6 @@ public final class TerasologyGameVersions {
         }
 
         // With the build numbers in hand we can go check for any existing installs locally
-        // TODO: Verify this actually can recognize new-style builds (with Terasology.jar moved)
         loadInstalledGames(gameDirectory, buildNumbersMap);
 
         // For each job line now fill in the extra version details needed for each build
@@ -137,7 +136,6 @@ public final class TerasologyGameVersions {
             loadGameVersions(buildNumbers, job, gameVersionMap, cachedGameVersions);
 
             // Now go back over the list of good builds and match them to Omega builds if possible
-            // TODO: Verify that this is a suitable stuff to add this new piece + find where to use it later
             fillInOmegaBuilds(gameVersionMap, buildNumbers, job);
 
             // Finally update the local cache if appropriate (?)

--- a/src/main/java/org/terasology/launcher/game/TerasologyGameVersions.java
+++ b/src/main/java/org/terasology/launcher/game/TerasologyGameVersions.java
@@ -619,7 +619,13 @@ public final class TerasologyGameVersions {
      */
     public synchronized boolean updateGameVersionsAfterInstallation(File terasologyDirectory) {
         File engineJar = null;
-        File[] files = terasologyDirectory.listFiles();
+        File libsDir = new File(terasologyDirectory, DIR_LIBS);
+        if (!libsDir.exists()) {
+            logger.error("Failed to find the libs dir in {} - cannot update game versions", terasologyDirectory);
+            return false;
+        }
+
+        File[] files = libsDir.listFiles();
         if (files == null) {
             logger.error("No files returned trying to scan directory {} for game versioning", terasologyDirectory);
             return false;


### PR DESCRIPTION
~~This is a crude and incomplete first draft - NOT MERGE READY~~

But the launcher has been broken for too long and it is time to fix it (and get 2.0.0 out) even if it isn't super pretty and polished.

I'm putting this in a branch under MovingBlocks so hopefully somebody waking up any time now over in Europe can take a look and maybe tweak at it a little more (hi @skaldarnar @msteiger @Halamix2 @mkalb !) before I get back up - past 2 am here, wee.

In short two main things have been done.

* Hacky fix for detecting the engine jar correctly again. Real goofy and probably doesn't work everywhere but it lets the launcher download and launch the game again!
* Mapping has been introduced between the engine jobs and the Omega jobs in Jenkins - this works! So far as pulling back the info, it isn't being used yet but I've made a space for the Omega build number in the game version data.

I made and worked off a quick diagram of the current state with the develop engine job + Omega:

![launcherjenkins](https://cloud.githubusercontent.com/assets/1063833/7336142/12c15aee-ebbb-11e4-8a4d-f780173e11f4.png)

Points of interest: 

* Omega build 134 is ignored and engine 1401 is correctly mapped to Omega 135 instead
* Omega build 113 was deleted for some reason, a warning is logged when the launcher considers engine 1380 which probably was what resulted in the deleted Omega build. We should add something visible there - engine alone could still be OK to download but it should be flagged
* Engine builds 1381 and 1379 aren't even considered (current functionality - one is deleted and one failed)
* *Edit:* Omega 120 also was a rebuild. Didn't even notice, but the logging caught it. Neat!

I had to bump up the range for the develop job to actually hit older more interesting scenarios so instead of considering 9 now 40 are evaluated (which in turn checks 80 Omega builds). We should probably put that back or add detection for when Omega goes past the desired oldest engine to consider.

Still todo

- [x] Actually store the Omega mapping in the game version info so it can be used later
- [x] If an Omega build is available for an engine job the user has selected download the Omega zip instead (there's some initial prep for that)
- [x] Stop going through older Omega builds if we're past the final engine build we care to see in the launcher
- [x] Check on how local builds react. I've not looked at the launcher much so this has been a crash course and I've skipped a bunch, especially local settings/cache. Launcher needs more javadoc, badly ;-)
- [x] Consider scenarios I've missed (I'm sure they're there, just too sleepy to work at it any longer)
- [x] Remove all the dirty debug logging and other hacks (maybe with some Git squashing)
- [ ] Figure out why setting stable 50 as the cutoff excludes it yet setting 49 includes it. 50 should be the oldest acceptable stable release for launcher v2.0.0
- [ ] Testing! Especially unusual cases
- [ ] Maybe fix #319 - tricky if you can't run the launcher "blank" on Java 8 yet need to run the latest develop with Java 8 ...
- [ ] Merge in the translation PR
- [ ] Finish the changelog
- [ ] ??? 
- [ ] Profit! And release 2.0.0 already