### PR TITLE
FX Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,11 @@ apply from: 'bundles.gradle';
 
 // Test for right version of Java in use for running this script
 assert org.gradle.api.JavaVersion.current().isJava8Compatible()
+def javaVersion = System.properties['java.version']
+// make sure at least 8u40 is used for the build (required for JavaFX)
+if (javaVersion.startsWith("1.8") && javaVersion.split("_")[1].toInteger() < 40) {
+    throw new GradleException("Java version 1.8.0_40 or later required, but was $javaVersion")
+}
 
 // gradle wrapper version
 wrapper {

--- a/src/main/java/org/terasology/launcher/LauncherInitTask.java
+++ b/src/main/java/org/terasology/launcher/LauncherInitTask.java
@@ -18,7 +18,7 @@ package org.terasology.launcher;
 
 import javafx.application.Platform;
 import javafx.concurrent.Task;
-import javafx.stage.Window;
+import javafx.stage.Stage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.launcher.game.GameJob;
@@ -40,9 +40,9 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
 
     private static final Logger logger = LoggerFactory.getLogger(LauncherInitTask.class);
 
-    private final Window owner;
+    private final Stage owner;
 
-    public LauncherInitTask(final Window newOwner) {
+    public LauncherInitTask(final Stage newOwner) {
         this.owner = newOwner;
     }
 
@@ -104,7 +104,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
         if (os == OperatingSystem.UNKNOWN) {
             logger.error("The operating system is not supported! '{}' '{}' '{}'", System.getProperty("os.name"), System.getProperty("os.arch"),
                 System.getProperty("os.version"));
-            GuiUtils.showErrorMessageDialog(null, BundleUtils.getLabel("message_error_operatingSystem"));
+            GuiUtils.showErrorMessageDialog(owner, BundleUtils.getLabel("message_error_operatingSystem"));
             throw new LauncherStartFailedException();
         }
         logger.debug("Operating system: {}", os);
@@ -118,7 +118,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
             DirectoryUtils.checkDirectory(launcherDirectory);
         } catch (IOException e) {
             logger.error("The launcher directory can not be created or used! '{}'", launcherDirectory, e);
-            GuiUtils.showErrorMessageDialog(null, BundleUtils.getLabel("message_error_launcherDirectory") + "\n" + launcherDirectory);
+            GuiUtils.showErrorMessageDialog(owner, BundleUtils.getLabel("message_error_launcherDirectory") + "\n" + launcherDirectory);
             throw new LauncherStartFailedException();
         }
         logger.debug("Launcher directory: {}", launcherDirectory);
@@ -132,7 +132,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
             DirectoryUtils.checkDirectory(downloadDirectory);
         } catch (IOException e) {
             logger.error("The download directory can not be created or used! '{}'", downloadDirectory, e);
-            GuiUtils.showErrorMessageDialog(null, BundleUtils.getLabel("message_error_downloadDirectory") + "\n" + downloadDirectory);
+            GuiUtils.showErrorMessageDialog(owner, BundleUtils.getLabel("message_error_downloadDirectory") + "\n" + downloadDirectory);
             throw new LauncherStartFailedException();
         }
         logger.debug("Download directory: {}", downloadDirectory);
@@ -146,7 +146,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
             DirectoryUtils.checkDirectory(tempDirectory);
         } catch (IOException e) {
             logger.error("The temp directory can not be created or used! '{}'", tempDirectory, e);
-            GuiUtils.showErrorMessageDialog(null, BundleUtils.getLabel("message_error_tempDirectory") + "\n" + tempDirectory);
+            GuiUtils.showErrorMessageDialog(owner, BundleUtils.getLabel("message_error_tempDirectory") + "\n" + tempDirectory);
             throw new LauncherStartFailedException();
         }
         try {
@@ -167,7 +167,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
             launcherSettings.init();
         } catch (IOException e) {
             logger.error("The launcher settings can not be loaded or initialized! '{}'", launcherSettings.getLauncherSettingsFilePath(), e);
-            GuiUtils.showErrorMessageDialog(null, BundleUtils.getLabel("message_error_loadSettings") + "\n" + launcherSettings.getLauncherSettingsFilePath());
+            GuiUtils.showErrorMessageDialog(owner, BundleUtils.getLabel("message_error_loadSettings") + "\n" + launcherSettings.getLauncherSettingsFilePath());
             throw new LauncherStartFailedException();
         }
         logger.debug("Launcher Settings: {}", launcherSettings);
@@ -188,11 +188,11 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
                 foundLauncherInstallationDirectory = true;
             } catch (URISyntaxException | IOException e) {
                 logger.error("The launcher installation directory can not be detected or used!", e);
-                GuiUtils.showErrorMessageDialog(null, BundleUtils.getLabel("message_error_launcherInstallationDirectory"));
+                GuiUtils.showErrorMessageDialog(owner, BundleUtils.getLabel("message_error_launcherInstallationDirectory"));
                 // Run launcher without an update. Don't throw a LauncherStartFailedException.
             }
             if (foundLauncherInstallationDirectory) {
-                final boolean update = updater.showUpdateDialog(null);
+                final boolean update = updater.showUpdateDialog(owner);
                 if (update) {
                     if (saveDownloadedFiles) {
                         selfUpdaterStarted = updater.update(downloadDirectory, tempDirectory);
@@ -213,7 +213,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
                 DirectoryUtils.checkDirectory(gameDirectory);
             } catch (IOException e) {
                 logger.warn("The game directory can not be created or used! '{}'", gameDirectory, e);
-                GuiUtils.showWarningMessageDialog(null, BundleUtils.getLabel("message_error_gameDirectory") + "\n" + gameDirectory);
+                GuiUtils.showWarningMessageDialog(owner, BundleUtils.getLabel("message_error_gameDirectory") + "\n" + gameDirectory);
 
                 // Set gameDirectory to 'null' -> user has to choose new game directory
                 gameDirectory = null;
@@ -233,7 +233,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
             DirectoryUtils.checkDirectory(gameDirectory);
         } catch (IOException e) {
             logger.error("The game directory can not be created or used! '{}'", gameDirectory, e);
-            GuiUtils.showErrorMessageDialog(null, BundleUtils.getLabel("message_error_gameDirectory") + "\n" + gameDirectory);
+            GuiUtils.showErrorMessageDialog(owner, BundleUtils.getLabel("message_error_gameDirectory") + "\n" + gameDirectory);
             throw new LauncherStartFailedException();
         }
         logger.debug("Game directory: {}", gameDirectory);
@@ -248,7 +248,8 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
                 DirectoryUtils.checkDirectory(gameDataDirectory);
             } catch (IOException e) {
                 logger.warn("The game data directory can not be created or used! '{}'", gameDataDirectory, e);
-                GuiUtils.showWarningMessageDialog(null, BundleUtils.getLabel("message_error_gameDataDirectory") + "\n" + gameDataDirectory);
+                GuiUtils.showWarningMessageDialog(owner, BundleUtils.getLabel("message_error_gameDataDirectory") + "\n" +
+                        gameDataDirectory);
 
                 // Set gameDataDirectory to 'null' -> user has to choose new game data directory
                 gameDataDirectory = null;
@@ -268,7 +269,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
             DirectoryUtils.checkDirectory(gameDataDirectory);
         } catch (IOException e) {
             logger.error("The game data directory can not be created or used! '{}'", gameDataDirectory, e);
-            GuiUtils.showErrorMessageDialog(null, BundleUtils.getLabel("message_error_gameDataDirectory") + "\n" + gameDataDirectory);
+            GuiUtils.showErrorMessageDialog(owner, BundleUtils.getLabel("message_error_gameDataDirectory") + "\n" + gameDataDirectory);
             throw new LauncherStartFailedException();
         }
         logger.debug("Game data directory: {}", gameDataDirectory);
@@ -296,7 +297,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
             launcherSettings.store();
         } catch (IOException e) {
             logger.error("The launcher settings can not be stored! '{}'", launcherSettings.getLauncherSettingsFilePath(), e);
-            GuiUtils.showErrorMessageDialog(null, BundleUtils.getLabel("message_error_storeSettings"));
+            GuiUtils.showErrorMessageDialog(owner, BundleUtils.getLabel("message_error_storeSettings"));
             throw new LauncherStartFailedException();
         }
         logger.debug("Launcher Settings stored: {}", launcherSettings);

--- a/src/main/java/org/terasology/launcher/TerasologyLauncher.java
+++ b/src/main/java/org/terasology/launcher/TerasologyLauncher.java
@@ -18,7 +18,6 @@ package org.terasology.launcher;
 
 import javafx.animation.FadeTransition;
 import javafx.application.Application;
-import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.concurrent.Task;
@@ -116,7 +115,7 @@ public final class TerasologyLauncher extends Application {
             }
         });
 
-        Platform.runLater(initThread);
+        initThread.start();
     }
 
     /**

--- a/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
@@ -29,7 +29,9 @@ import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Accordion;
+import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.ProgressBar;
@@ -57,10 +59,10 @@ import org.terasology.launcher.log.LogViewAppender;
 import org.terasology.launcher.util.BundleUtils;
 import org.terasology.launcher.util.DirectoryUtils;
 import org.terasology.launcher.util.FileUtils;
+import org.terasology.launcher.util.GuiUtils;
 import org.terasology.launcher.util.Languages;
 import org.terasology.launcher.version.TerasologyLauncherVersionInfo;
 
-import javax.swing.JOptionPane;
 import java.awt.Desktop;
 import java.io.BufferedReader;
 import java.io.File;
@@ -75,6 +77,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.ResourceBundle;
 
 public class ApplicationController {
@@ -198,19 +201,15 @@ public class ApplicationController {
         final TerasologyGameVersion gameVersion = getSelectedGameVersion();
         if ((gameVersion == null) || !gameVersion.isInstalled()) {
             logger.warn("The selected game version can not be started! '{}'", gameVersion);
-            JOptionPane.showMessageDialog(null, BundleUtils.getLabel("message_error_gameStart"),
-                    BundleUtils.getLabel("message_error_title"), JOptionPane.ERROR_MESSAGE);
-            // updateGui();
+            GuiUtils.showErrorMessageDialog(stage, BundleUtils.getLabel("message_error_gameStart"));
         } else if (gameStarter.isRunning()) {
             logger.debug("The game can not be started because another game is already running.");
-            JOptionPane.showMessageDialog(null, BundleUtils.getLabel("message_information_gameRunning"),
-                BundleUtils.getLabel("message_information_title"), JOptionPane.INFORMATION_MESSAGE);
+            GuiUtils.showInfoMessageDialog(stage, BundleUtils.getLabel("message_information_gameRunning"));
         } else {
             final boolean gameStarted = gameStarter.startGame(gameVersion, launcherSettings.getGameDataDirectory(), launcherSettings.getMaxHeapSize(),
                 launcherSettings.getInitialHeapSize(), launcherSettings.getUserJavaParameterList(), launcherSettings.getUserGameParameterList());
             if (!gameStarted) {
-                JOptionPane.showMessageDialog(null, BundleUtils.getLabel("message_error_gameStart"),
-                    BundleUtils.getLabel("message_error_title"), JOptionPane.ERROR_MESSAGE);
+                GuiUtils.showErrorMessageDialog(stage, BundleUtils.getLabel("message_error_gameStart"));
             } else if (launcherSettings.isCloseLauncherAfterGameStart()) {
                 if (gameDownloadWorker == null) {
                     logger.info("Close launcher after game start.");
@@ -268,8 +267,13 @@ public class ApplicationController {
             } else {
                 msg = BundleUtils.getMessage("confirmDeleteGame_withoutData", gameVersion.getInstallationPath());
             }
-            final int option = JOptionPane.showConfirmDialog(null, msg, BundleUtils.getLabel("message_deleteGame_title"), JOptionPane.YES_NO_OPTION);
-            if (option == JOptionPane.YES_OPTION) {
+            final Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
+            alert.setContentText(msg);
+            alert.setTitle(BundleUtils.getLabel("message_deleteGame_title"));
+            alert.initOwner(stage);
+
+            Optional<ButtonType> result = alert.showAndWait();
+            if (result.get() == ButtonType.OK) {
                 logger.info("Delete installed game! '{}' '{}'", gameVersion, gameVersion.getInstallationPath());
                 try {
                     FileUtils.delete(gameVersion.getInstallationPath());
@@ -695,15 +699,12 @@ public class ApplicationController {
         progressBar.setVisible(false);
         if (!cancelled) {
             if (!successfulDownloadAndExtract) {
-                JOptionPane.showMessageDialog(null, BundleUtils.getLabel("message_error_gameDownload_downloadExtract"),
-                    BundleUtils.getLabel("message_error_title"), JOptionPane.ERROR_MESSAGE);
+                GuiUtils.showErrorMessageDialog(stage, BundleUtils.getLabel("message_error_gameDownload_downloadExtract"));
             } else if (!successfulLoadVersion) {
                 if (gameDirectory != null) {
-                    JOptionPane.showMessageDialog(null, BundleUtils.getLabel("message_error_gameDownload_loadVersion") + "\n" + gameDirectory,
-                        BundleUtils.getLabel("message_error_title"), JOptionPane.ERROR_MESSAGE);
+                    GuiUtils.showErrorMessageDialog(stage, BundleUtils.getLabel("message_error_gameDownload_loadVersion") + "\n" + gameDirectory);
                 } else {
-                    JOptionPane.showMessageDialog(null, BundleUtils.getLabel("message_error_gameDownload_loadVersion"),
-                        BundleUtils.getLabel("message_error_title"), JOptionPane.ERROR_MESSAGE);
+                    GuiUtils.showErrorMessageDialog(stage, BundleUtils.getLabel("message_error_gameDownload_loadVersion"));
                 }
             }
         }

--- a/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
@@ -77,7 +77,6 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.ResourceBundle;
 
 public class ApplicationController {
@@ -272,19 +271,21 @@ public class ApplicationController {
             alert.setTitle(BundleUtils.getLabel("message_deleteGame_title"));
             alert.initOwner(stage);
 
-            Optional<ButtonType> result = alert.showAndWait();
-            if (result.get() == ButtonType.OK) {
-                logger.info("Delete installed game! '{}' '{}'", gameVersion, gameVersion.getInstallationPath());
-                try {
-                    FileUtils.delete(gameVersion.getInstallationPath());
-                } catch (IOException e) {
-                    logger.error("Could not delete installed game!", e);
-                    // TODO Show message dialog
-                    return;
-                }
-                gameVersions.removeInstallationInfo(gameVersion);
-                updateGui();
-            }
+            alert.showAndWait()
+                    .filter(response -> response == ButtonType.OK)
+                    .ifPresent(response -> {
+                        logger.info("Delete installed game! '{}' '{}'", gameVersion, gameVersion.getInstallationPath());
+                        try {
+                            FileUtils.delete(gameVersion.getInstallationPath());
+                        } catch (IOException e) {
+                            logger.error("Could not delete installed game!", e);
+                            // TODO: introduce new message label
+                            GuiUtils.showWarningMessageDialog(stage, "Could not delete installed game!");
+                            return;
+                        }
+                        gameVersions.removeInstallationInfo(gameVersion);
+                        updateGui();
+                    });
         } else {
             logger.warn("The selected game version can not be deleted! '{}'", gameVersion);
         }

--- a/src/main/java/org/terasology/launcher/gui/javafx/SettingsController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/SettingsController.java
@@ -41,7 +41,6 @@ import org.terasology.launcher.util.GuiUtils;
 import org.terasology.launcher.util.JavaHeapSize;
 import org.terasology.launcher.util.Languages;
 
-import javax.swing.JOptionPane;
 import java.awt.Desktop;
 import java.io.File;
 import java.io.IOException;
@@ -142,10 +141,7 @@ public class SettingsController {
             launcherSettings.store();
         } catch (IOException e) {
             logger.error("The launcher settings can not be stored! '{}'", launcherSettings.getLauncherSettingsFilePath(), e);
-            JOptionPane.showMessageDialog(null,
-                BundleUtils.getLabel("message_error_storeSettings"),
-                BundleUtils.getLabel("message_error_title"),
-                JOptionPane.ERROR_MESSAGE);
+            GuiUtils.showErrorMessageDialog(stage, BundleUtils.getLabel("message_error_storeSettings"));
         } finally {
             ((Node) event.getSource()).getScene().getWindow().hide();
         }
@@ -158,10 +154,7 @@ public class SettingsController {
             Desktop.getDesktop().open(gameDirectory);
         } catch (IOException e) {
             logger.error("The game directory can not be opened! '{}'", gameDirectory, e);
-            JOptionPane.showMessageDialog(null,
-                BundleUtils.getLabel("message_error_gameDirectory") + "\n" + gameDirectory,
-                BundleUtils.getLabel("message_error_title"),
-                JOptionPane.ERROR_MESSAGE);
+            GuiUtils.showErrorMessageDialog(stage, BundleUtils.getLabel("message_error_gameDirectory") + "\n" + gameDirectory);
         }
     }
 
@@ -175,10 +168,7 @@ public class SettingsController {
                 updateDirectoryPathLabels();
             } catch (IOException e) {
                 logger.error("The game directory can not be created or used! '{}'", gameDirectory, e);
-                JOptionPane.showMessageDialog(null,
-                    BundleUtils.getLabel("message_error_gameDirectory") + "\n" + gameDirectory,
-                    BundleUtils.getLabel("message_error_title"),
-                    JOptionPane.ERROR_MESSAGE);
+                GuiUtils.showErrorMessageDialog(stage, BundleUtils.getLabel("message_error_gameDirectory") + "\n" + gameDirectory);
             }
         }
     }
@@ -190,10 +180,7 @@ public class SettingsController {
             Desktop.getDesktop().open(gameDataDirectory);
         } catch (IOException e) {
             logger.error("The game data directory can not be opened! '{}'", gameDataDirectory, e);
-            JOptionPane.showMessageDialog(null,
-                BundleUtils.getLabel("message_error_gameDataDirectory") + "\n" + gameDataDirectory,
-                BundleUtils.getLabel("message_error_title"),
-                JOptionPane.ERROR_MESSAGE);
+            GuiUtils.showErrorMessageDialog(stage, BundleUtils.getLabel("message_error_gameDataDirectory") + "\n" + gameDataDirectory);
         }
     }
 
@@ -207,10 +194,7 @@ public class SettingsController {
                 updateDirectoryPathLabels();
             } catch (IOException e) {
                 logger.error("The game data directory can not be created or used! '{}'", gameDataDirectory, e);
-                JOptionPane.showMessageDialog(null,
-                    BundleUtils.getLabel("message_error_gameDataDirectory") + "\n" + gameDataDirectory,
-                    BundleUtils.getLabel("message_error_title"),
-                    JOptionPane.ERROR_MESSAGE);
+                GuiUtils.showErrorMessageDialog(stage, BundleUtils.getLabel("message_error_gameDataDirectory") + "\n" + gameDataDirectory);
             }
         }
     }
@@ -222,10 +206,7 @@ public class SettingsController {
             Desktop.getDesktop().open(launcherDirectory);
         } catch (IOException e) {
             logger.error("The game launcher directory can not be opened! '{}'", launcherDirectory, e);
-            JOptionPane.showMessageDialog(null,
-                BundleUtils.getLabel("message_error_launcherDirectory") + "\n" + launcherDirectory,
-                BundleUtils.getLabel("message_error_title"),
-                JOptionPane.ERROR_MESSAGE);
+            GuiUtils.showErrorMessageDialog(stage, BundleUtils.getLabel("message_error_launcherDirectory") + "\n" + launcherDirectory);
         }
     }
 
@@ -236,10 +217,7 @@ public class SettingsController {
             Desktop.getDesktop().open(downloadDirectory);
         } catch (IOException e) {
             logger.error("The game download directory can not be opened! '{}'", downloadDirectory, e);
-            JOptionPane.showMessageDialog(null,
-                BundleUtils.getLabel("message_error_downloadDirectory") + "\n" + downloadDirectory,
-                BundleUtils.getLabel("message_error_title"),
-                JOptionPane.ERROR_MESSAGE);
+            GuiUtils.showErrorMessageDialog(stage, BundleUtils.getLabel("message_error_downloadDirectory") + "\n" + downloadDirectory);
         }
     }
 

--- a/src/main/java/org/terasology/launcher/util/BundleUtils.java
+++ b/src/main/java/org/terasology/launcher/util/BundleUtils.java
@@ -21,10 +21,6 @@ import javafx.scene.image.Image;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.imageio.ImageIO;
-import javax.swing.ImageIcon;
-import java.awt.image.BufferedImage;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -84,16 +80,6 @@ public final class BundleUtils {
             logger.error("Could not create URI '{}' for key '{}'!", uriStr, key, e);
         }
         return null;
-    }
-
-    public static ImageIcon getImageIcon(String key) {
-        final String imagePath = ResourceBundle.getBundle(IMAGE_BUNDLE, Languages.getCurrentLocale()).getString(key);
-        return new ImageIcon(BundleUtils.class.getResource(imagePath));
-    }
-
-    public static BufferedImage getImage(String key) throws IOException {
-        final String imagePath = ResourceBundle.getBundle(IMAGE_BUNDLE, Languages.getCurrentLocale()).getString(key);
-        return ImageIO.read(BundleUtils.class.getResourceAsStream(imagePath));
     }
 
     /**

--- a/src/main/java/org/terasology/launcher/util/DirectoryUtils.java
+++ b/src/main/java/org/terasology/launcher/util/DirectoryUtils.java
@@ -16,9 +16,9 @@
 
 package org.terasology.launcher.util;
 
+import javafx.stage.DirectoryChooser;
 import org.terasology.launcher.util.windows.SavedGamesPathFinder;
 
-import javax.swing.JFileChooser;
 import java.io.File;
 import java.io.IOException;
 import java.util.Locale;
@@ -158,7 +158,7 @@ public final class DirectoryUtils {
                 }
             }
             if (path == null) {
-                path = new JFileChooser().getFileSystemView().getDefaultDirectory();
+                path = new DirectoryChooser().getInitialDirectory();
             }
 
             gameDataDirectory = new File(path, GAME_DATA_DIR_NAME + '\\');

--- a/src/main/java/org/terasology/launcher/util/GuiUtils.java
+++ b/src/main/java/org/terasology/launcher/util/GuiUtils.java
@@ -18,30 +18,51 @@ package org.terasology.launcher.util;
 
 import javafx.application.Platform;
 import javafx.concurrent.Task;
+import javafx.scene.control.Alert;
 import javafx.stage.DirectoryChooser;
-import javafx.stage.Window;
+import javafx.stage.Stage;
 
-import javax.swing.JOptionPane;
-import java.awt.Component;
 import java.io.File;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
 
 public final class GuiUtils {
 
     private GuiUtils() {
     }
 
-    public static void showWarningMessageDialog(Component parentComponent, String message) {
-        // TODO: Java8 -- Use ControlsFX dialog
-        JOptionPane.showMessageDialog(parentComponent, message, BundleUtils.getLabel("message_error_title"), JOptionPane.WARNING_MESSAGE);
+    private static void showMessageDialog(Alert.AlertType type, String title, String message, Stage owner) {
+        FutureTask<Void> dialog = new FutureTask<>(() -> {
+            final Alert alert = new Alert(type);
+            alert.setTitle(title);
+            alert.setContentText(message);
+            alert.initOwner(owner);
+
+            alert.showAndWait();
+            return null;
+        });
+
+        Platform.runLater(dialog);
+        try {
+            dialog.get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
     }
 
-    public static void showErrorMessageDialog(Component parentComponent, String message) {
-        // TODO: Java8 -- Use ControlsFX dialog
-        JOptionPane.showMessageDialog(parentComponent, message, BundleUtils.getLabel("message_error_title"), JOptionPane.ERROR_MESSAGE);
+    public static void showWarningMessageDialog(Stage owner, String message) {
+        showMessageDialog(Alert.AlertType.WARNING, BundleUtils.getLabel("message_error_title"), message, owner);
     }
 
-    public static File chooseDirectoryDialog(Window parentWindow, final File directory, final String title) {
+    public static void showErrorMessageDialog(Stage owner, String message) {
+        showMessageDialog(Alert.AlertType.ERROR, BundleUtils.getLabel("message_error_title"), message, owner);
+    }
+
+    public static void showInfoMessageDialog(Stage owner, String message) {
+        showMessageDialog(Alert.AlertType.INFORMATION, BundleUtils.getLabel("message_information_title"), message, owner);
+    }
+
+    public static File chooseDirectoryDialog(Stage owner, final File directory, final String title) {
         if (!directory.isDirectory()) {
             directory.mkdir();
         }
@@ -52,7 +73,7 @@ public final class GuiUtils {
                 final DirectoryChooser directoryChooser = new DirectoryChooser();
                 directoryChooser.setInitialDirectory(directory);
                 directoryChooser.setTitle(title);
-                final File selected = directoryChooser.showDialog(parentWindow);
+                final File selected = directoryChooser.showDialog(owner);
                 return selected;
             }
         };

--- a/src/main/resources/org/terasology/launcher/bundle/FXMLBundle.properties
+++ b/src/main/resources/org/terasology/launcher/bundle/FXMLBundle.properties
@@ -16,6 +16,7 @@
 
 application=/org/terasology/launcher/views/application.fxml
 settings=/org/terasology/launcher/views/settings.fxml
+update_dialog=/org/terasology/launcher/views/update_dialog.fxml
 
 css_terasology=/org/terasology/launcher/views/terasology.css
 css_webview=/org/terasology/launcher/views/webview.css

--- a/src/main/resources/org/terasology/launcher/views/update_dialog.fxml
+++ b/src/main/resources/org/terasology/launcher/views/update_dialog.fxml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import java.lang.*?>
+<?import javafx.scene.layout.*?>
+
+
+<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="720.0" xmlns="http://javafx.com/javafx/8.0.45" xmlns:fx="http://javafx.com/fxml/1">
+   <center>
+      <VBox spacing="8.0" BorderPane.alignment="CENTER">
+         <children>
+            <TextArea id="infoTextArea" editable="false" prefHeight="75.0" prefRowCount="3" prefWidth="704.0" VBox.vgrow="NEVER">
+               <VBox.margin>
+                  <Insets />
+               </VBox.margin>
+            </TextArea>
+            <TextArea id="changelogTextArea" editable="false" prefHeight="200.0" prefWidth="200.0" VBox.vgrow="ALWAYS" />
+         </children>
+         <BorderPane.margin>
+            <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
+         </BorderPane.margin>
+      </VBox>
+   </center>
+</BorderPane>


### PR DESCRIPTION
This PR mainly cleans up the old Swing code and replaces it with Java FX 8 equivalents. This should also solve the task tangling of background and FX thread when invoking message dialogs (errors, warnings, info, confirmation) via the `GuiUtils` helper methods.

Note to self: add a note in the wiki on how to use the `GuiUtils` wrapper methods properly (and why they are there in the first place).

@Cervator - can you test this please? I did a quick run and all seems fine, but four eyes are better than two :wink: 