### PR TITLE
Use HostServices instead of Desktop to open files/URLs externally.

### DIFF
--- a/src/main/java/org/terasology/launcher/TerasologyLauncher.java
+++ b/src/main/java/org/terasology/launcher/TerasologyLauncher.java
@@ -18,6 +18,7 @@ package org.terasology.launcher;
 
 import javafx.animation.FadeTransition;
 import javafx.application.Application;
+import javafx.application.HostServices;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.concurrent.Task;
@@ -69,6 +70,7 @@ public final class TerasologyLauncher extends Application {
     private ProgressBar loadProgress;
     private Label progressText;
     private Stage mainStage;
+    private HostServices hostServices;
 
     public static void main(String[] args) {
         launch(args);
@@ -85,6 +87,7 @@ public final class TerasologyLauncher extends Application {
         progressText.setAlignment(Pos.CENTER);
         splashLayout.getStylesheets().add(BundleUtils.getStylesheet("css_splash"));
         splashLayout.setEffect(new DropShadow());
+        hostServices = getHostServices();
     }
 
     @Override
@@ -157,7 +160,7 @@ public final class TerasologyLauncher extends Application {
         }
         final ApplicationController controller = fxmlLoader.getController();
         controller.initialize(launcherConfiguration.getLauncherDirectory(), launcherConfiguration.getDownloadDirectory(), launcherConfiguration.getTempDirectory(),
-            launcherConfiguration.getLauncherSettings(), launcherConfiguration.getGameVersions(), mainStage);
+            launcherConfiguration.getLauncherSettings(), launcherConfiguration.getGameVersions(), mainStage, hostServices);
 
         Scene scene = new Scene(root);
         scene.getStylesheets().add(BundleUtils.getStylesheet("css_terasology"));

--- a/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
@@ -19,8 +19,10 @@ package org.terasology.launcher.gui.javafx;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.github.rjeschke.txtmark.Configuration;
 import com.github.rjeschke.txtmark.Processor;
+import com.sun.javafx.application.HostServicesDelegate;
 import javafx.animation.ScaleTransition;
 import javafx.animation.Transition;
+import javafx.application.HostServices;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.fxml.FXML;
@@ -91,6 +93,7 @@ public class ApplicationController {
     private GameStarter gameStarter;
     private GameDownloadWorker gameDownloadWorker;
     private Stage stage;
+    private HostServices hostServies;
 
     @FXML
     private ChoiceBox<JobItem> jobBox;
@@ -322,13 +325,14 @@ public class ApplicationController {
     }
 
     public void initialize(final File newLauncherDirectory, final File newDownloadDirectory, final File newTempDirectory, final LauncherSettings newLauncherSettings,
-                           final TerasologyGameVersions newGameVersions, final Stage newStage) {
+                           final TerasologyGameVersions newGameVersions, final Stage newStage, final HostServices hostServices) {
         this.launcherDirectory = newLauncherDirectory;
         this.downloadDirectory = newDownloadDirectory;
         this.tempDirectory = newTempDirectory;
         this.launcherSettings = newLauncherSettings;
         this.gameVersions = newGameVersions;
         this.stage = newStage;
+        this.hostServies = hostServices;
 
         // add Logback view appender view to both the root logger and the tab
         Logger rootLogger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
@@ -425,15 +429,8 @@ public class ApplicationController {
     }
 
     private void openUri(URI uri) {
-        if ((uri != null) && Desktop.isDesktopSupported()) {
-            final Desktop desktop = Desktop.getDesktop();
-            if (desktop.isSupported(Desktop.Action.BROWSE)) {
-                try {
-                    desktop.browse(uri);
-                } catch (IOException | RuntimeException e) {
-                    logger.error("Could not browse URI '{}' with desktop!", uri, e);
-                }
-            }
+        if (uri != null) {
+            hostServies.showDocument(uri.toString());
         }
     }
 


### PR DESCRIPTION
This is another attempt to prevent the launcher from freezing when opening links in the browser under Linux. Likely fixes #342.