### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/org/terasology/launcher/game/TerasologyGameVersions.java
+++ b/src/main/java/org/terasology/launcher/game/TerasologyGameVersions.java
@@ -208,7 +208,7 @@ public final class TerasologyGameVersions {
             if ((lastSuccessfulBuildNumber != null) && (lastSuccessfulBuildNumber >= job.getMinBuildNumber())) {
                 buildNumbers.add(lastSuccessfulBuildNumber);
                 // add previous build numbers
-                for (int buildNumber = lastSuccessfulBuildNumber - 1; ((buildNumbers.size() <= job.getPrevBuildNumbers()) && buildNumber > job.getMinBuildNumber());
+                for (int buildNumber = lastSuccessfulBuildNumber - 1; (buildNumbers.size() <= job.getPrevBuildNumbers() && buildNumber > job.getMinBuildNumber());
                      buildNumber--) {
                     try {
                         // Skip unavailable builds
@@ -486,7 +486,7 @@ public final class TerasologyGameVersions {
                 Boolean successful = null;
                 try {
                     JobResult jobResult = DownloadUtils.loadJobResultJenkins(job.name(), buildNumber);
-                    successful = (jobResult != null && ((jobResult == JobResult.SUCCESS) || (jobResult == JobResult.UNSTABLE)));
+                    successful = jobResult != null && ((jobResult == JobResult.SUCCESS) || (jobResult == JobResult.UNSTABLE));
                 } catch (DownloadException e) {
                     logger.warn("Failed to load job result (probably OK): '{}' '{}'", job, buildNumber);
                 }

--- a/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
@@ -680,7 +680,7 @@ public class ApplicationController {
         }
 
         /* Append changelogs of previous builds. */
-        int previousLogs = (gameVersion.getJob().isStable()) ? 1 : 10;
+        int previousLogs = gameVersion.getJob().isStable() ? 1 : 10;
         b.append("<hr/>");
         for (String msg : gameVersions.getAggregatedChangeLog(gameVersion, previousLogs)) {
             b.append("<li>");

--- a/src/main/java/org/terasology/launcher/settings/LauncherSettingsDecorator.java
+++ b/src/main/java/org/terasology/launcher/settings/LauncherSettingsDecorator.java
@@ -155,12 +155,12 @@ public class LauncherSettingsDecorator extends LauncherSettings {
 
     @Override
     public Integer getBuildVersion(GameJob job) {
-        return (buildVersionMap.containsKey(job)) ? buildVersionMap.get(job) : settings.getBuildVersion(job);
+        return buildVersionMap.containsKey(job) ? buildVersionMap.get(job) : settings.getBuildVersion(job);
     }
 
     @Override
     public Integer getLastBuildNumber(GameJob job) {
-        return (lastBuildNumberMap.containsKey(job)) ? lastBuildNumberMap.get(job) : settings.getLastBuildNumber(job);
+        return lastBuildNumberMap.containsKey(job) ? lastBuildNumberMap.get(job) : settings.getLastBuildNumber(job);
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Zeeshan Asghar