### PR TITLE
Methods should not be empty

### DIFF
--- a/src/main/java/org/terasology/launcher/settings/LauncherSettingsDecorator.java
+++ b/src/main/java/org/terasology/launcher/settings/LauncherSettingsDecorator.java
@@ -71,32 +71,32 @@ public class LauncherSettingsDecorator extends LauncherSettings {
 
     @Override
     protected void initInitialHeapSize() {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     protected void initSearchForLauncherUpdates() {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     protected void initCloseLauncherAfterGameStart() {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     protected void initSaveDownloadedFiles() {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     protected void initGameDirectory() {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     protected void initGameDataDirectory() {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -106,37 +106,37 @@ public class LauncherSettingsDecorator extends LauncherSettings {
 
     @Override
     protected void initUserGameParameters() {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     protected void initLogLevel() {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     protected void initMaxHeapSize() {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     protected void initLastBuildNumber() {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     protected void initLocale() {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     protected void initJob() {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     protected void initBuildVersion() {
-
+        throw new UnsupportedOperationException();
     }
 
     // --------------------------------------------------------------------- //


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1186 Methods should not be empty

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1186

Please let me know if you have any questions.

Zeeshan Asghar