### PR TITLE
String literals should not be duplicated

### DIFF
--- a/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
@@ -82,6 +82,7 @@ import java.util.ResourceBundle;
 public class ApplicationController {
 
     private static final Logger logger = LoggerFactory.getLogger(ApplicationController.class);
+    private static final String ABOUT = "about";
 
     private File launcherDirectory;
     private File downloadDirectory;
@@ -539,10 +540,10 @@ public class ApplicationController {
         aboutInfoAccordion.getPanes().clear();
 
         Collection<URL> files = new ArrayList<>();
-        files.add(BundleUtils.getFXMLUrl("about", "README.md"));
-        files.add(BundleUtils.getFXMLUrl("about", "CHANGELOG.md"));
-        files.add(BundleUtils.getFXMLUrl("about", "CONTRIBUTING.md"));
-        files.add(BundleUtils.getFXMLUrl("about", "LICENSE"));
+        files.add(BundleUtils.getFXMLUrl(ABOUT, "README.md"));
+        files.add(BundleUtils.getFXMLUrl(ABOUT, "CHANGELOG.md"));
+        files.add(BundleUtils.getFXMLUrl(ABOUT, "CONTRIBUTING.md"));
+        files.add(BundleUtils.getFXMLUrl(ABOUT, "LICENSE"));
         Charset cs = Charset.forName("UTF-8");
 
         for (URL url : files) {

--- a/src/main/java/org/terasology/launcher/util/DownloadUtils.java
+++ b/src/main/java/org/terasology/launcher/util/DownloadUtils.java
@@ -69,6 +69,8 @@ public final class DownloadUtils {
 
     private static final int CONNECT_TIMEOUT = 1000 * 30;
     private static final int READ_TIMEOUT = 1000 * 60 * 5;
+    private static final String URL = ", URL=";
+    private static final String CLOSING_BUFFERED_READER_FOR_FAILED = "Closing BufferedReader for '{}' failed!";
 
     private DownloadUtils() {
     }
@@ -208,13 +210,13 @@ public final class DownloadUtils {
             reader = new BufferedReader(new InputStreamReader(urlVersion.openStream(), StandardCharsets.US_ASCII));
             buildNumber = Integer.parseInt(reader.readLine());
         } catch (IOException | RuntimeException e) {
-            throw new DownloadException("The build number could not be loaded! job=" + jobName + ", URL=" + urlVersion, e);
+            throw new DownloadException("The build number could not be loaded! job=" + jobName + URL + urlVersion, e);
         } finally {
             if (reader != null) {
                 try {
                     reader.close();
                 } catch (IOException e) {
-                    logger.warn("Closing BufferedReader for '{}' failed!", urlVersion, e);
+                    logger.warn(CLOSING_BUFFERED_READER_FOR_FAILED, urlVersion, e);
                 }
             }
         }
@@ -241,13 +243,13 @@ public final class DownloadUtils {
                 }
             }
         } catch (IOException | RuntimeException e) {
-            throw new DownloadException("The job result could not be loaded! job=" + jobName + ", URL=" + urlResult, e);
+            throw new DownloadException("The job result could not be loaded! job=" + jobName + URL + urlResult, e);
         } finally {
             if (reader != null) {
                 try {
                     reader.close();
                 } catch (IOException e) {
-                    logger.warn("Closing BufferedReader for '{}' failed!", urlResult, e);
+                    logger.warn(CLOSING_BUFFERED_READER_FOR_FAILED, urlResult, e);
                 }
             }
         }
@@ -281,7 +283,7 @@ public final class DownloadUtils {
                 }
             }
         } catch (ParserConfigurationException | SAXException | IOException | RuntimeException e) {
-            throw new DownloadException("The change log could not be loaded! job=" + jobName + ", URL=" + urlChangeLog, e);
+            throw new DownloadException("The change log could not be loaded! job=" + jobName + URL + urlChangeLog, e);
         }
         return changeLog;
     }
@@ -323,7 +325,7 @@ public final class DownloadUtils {
                 try {
                     reader.close();
                 } catch (IOException e) {
-                    logger.warn("Closing BufferedReader for '{}' failed!", urlResult, e);
+                    logger.warn(CLOSING_BUFFERED_READER_FOR_FAILED, urlResult, e);
                 }
             }
         }
@@ -348,13 +350,13 @@ public final class DownloadUtils {
                 changeLog.append(line);
             }
         } catch (IOException | RuntimeException e) {
-            throw new DownloadException("The launcher change log could not be loaded! job=" + jobName + ", URL=" + urlChangeLog, e);
+            throw new DownloadException("The launcher change log could not be loaded! job=" + jobName + URL + urlChangeLog, e);
         } finally {
             if (reader != null) {
                 try {
                     reader.close();
                 } catch (IOException e) {
-                    logger.warn("Closing BufferedReader for '{}' failed!", urlChangeLog, e);
+                    logger.warn(CLOSING_BUFFERED_READER_FOR_FAILED, urlChangeLog, e);
                 }
             }
         }

--- a/src/main/java/org/terasology/launcher/util/FileUtils.java
+++ b/src/main/java/org/terasology/launcher/util/FileUtils.java
@@ -31,6 +31,7 @@ import java.util.zip.ZipInputStream;
 public final class FileUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(FileUtils.class);
+    private static final String COULD_NOT_CREATE_DIRECTORY = "Could not create directory! ";
 
     private FileUtils() {
     }
@@ -91,7 +92,7 @@ public final class FileUtils {
             if (!outputLocation.exists()) {
                 boolean created = outputLocation.mkdir();
                 if (!created) {
-                    throw new IOException("Could not create directory! " + outputLocation);
+                    throw new IOException(COULD_NOT_CREATE_DIRECTORY + outputLocation);
                 }
             }
             final byte[] buffer = new byte[4096];
@@ -103,7 +104,7 @@ public final class FileUtils {
                     if (!extractedDir.exists()) {
                         boolean created = extractedDir.mkdirs();
                         if (!created) {
-                            throw new IOException("Could not create directory! " + extractedDir);
+                            throw new IOException(COULD_NOT_CREATE_DIRECTORY + extractedDir);
                         }
                     }
                     if (!ze.isDirectory()) {
@@ -150,7 +151,7 @@ public final class FileUtils {
             if (!destination.exists()) {
                 final boolean created = destination.mkdirs();
                 if (!created) {
-                    throw new IOException("Could not create directory! " + destination);
+                    throw new IOException(COULD_NOT_CREATE_DIRECTORY + destination);
                 }
             }
             final String[] files = source.list();

--- a/src/main/java/org/terasology/launcher/util/GuiUtils.java
+++ b/src/main/java/org/terasology/launcher/util/GuiUtils.java
@@ -76,7 +76,7 @@ public final class GuiUtils {
             return null;
         }
 
-        File selected = null;
+        File selected;
 
         if (Platform.isFxApplicationThread()) {
             final DirectoryChooser directoryChooser = new DirectoryChooser();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1192 String literals should not be duplicated

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1192

Please let me know if you have any questions.

Zeeshan Asghar