### PR TITLE
Further PMD fixes

### DIFF
--- a/src/main/java/org/terasology/launcher/LauncherInitTask.java
+++ b/src/main/java/org/terasology/launcher/LauncherInitTask.java
@@ -284,7 +284,9 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
         gameVersions.loadGameVersions(launcherSettings, launcherDirectory, gameDirectory);
         if (logger.isInfoEnabled()) {
             for (GameJob gameJob : GameJob.values()) {
-                logger.info("Game versions: {} {}", gameJob, gameVersions.getGameVersionList(gameJob).size() - 1);
+                if (logger.isInfoEnabled()) {
+                    logger.info("Game versions: {} {}", gameJob, gameVersions.getGameVersionList(gameJob).size() - 1);
+                }
             }
         }
         logger.debug("Game versions: {}", gameVersions);

--- a/src/main/java/org/terasology/launcher/game/TerasologyGameVersions.java
+++ b/src/main/java/org/terasology/launcher/game/TerasologyGameVersions.java
@@ -232,8 +232,9 @@ public final class TerasologyGameVersions {
      * @param job          the job line we're working on
      */
     private void fillInOmegaBuilds(SortedMap<Integer, TerasologyGameVersion> gameVersionMap, SortedSet<Integer> buildNumbers, GameJob job) {
-        if (logger.isInfoEnabled())
+        if (logger.isInfoEnabled()) {
             logger.info("Will try to load Omega build numbers from " + job.getOmegaJobName());
+        }
 
         // We more or less redo the original process in looking up the Omega job then later going back in history to map to the engine job
         Integer lastSuccessfulBuildNumber;
@@ -318,8 +319,9 @@ public final class TerasologyGameVersions {
             processed++;
         }
 
-        if (logger.isInfoEnabled())
+        if (logger.isInfoEnabled()) {
             logger.info("Processed " + processed + " out of " + gameVersionMap.size());
+        }
     }
 
     /**

--- a/src/main/java/org/terasology/launcher/settings/BaseLauncherSettings.java
+++ b/src/main/java/org/terasology/launcher/settings/BaseLauncherSettings.java
@@ -171,7 +171,7 @@ public final class BaseLauncherSettings extends AbstractLauncherSettings {
                     logger.warn(WARN_MSG_INVALID_VALUE, lastBuildNumberStr, key);
                 }
             }
-            if ((lastBuildNumber != null) && (lastBuildNumber >= j.getMinBuildNumber())) {
+            if (lastBuildNumber != null && lastBuildNumber >= j.getMinBuildNumber()) {
                 properties.setProperty(key, lastBuildNumber.toString());
             } else {
                 properties.setProperty(key, LAST_BUILD_NUMBER_DEFAULT);
@@ -262,7 +262,7 @@ public final class BaseLauncherSettings extends AbstractLauncherSettings {
     protected void initGameDirectory() {
         final String gameDirectoryStr = properties.getProperty(PROPERTY_GAME_DIRECTORY);
         File gameDirectory = null;
-        if ((gameDirectoryStr != null) && (gameDirectoryStr.trim().length() > 0)) {
+        if (gameDirectoryStr != null && gameDirectoryStr.trim().length() > 0) {
             try {
                 gameDirectory = new File(new URI(gameDirectoryStr));
             } catch (URISyntaxException | RuntimeException e) {
@@ -279,7 +279,7 @@ public final class BaseLauncherSettings extends AbstractLauncherSettings {
     protected void initGameDataDirectory() {
         final String gameDataDirectoryStr = properties.getProperty(PROPERTY_GAME_DATA_DIRECTORY);
         File gameDataDirectory = null;
-        if ((gameDataDirectoryStr != null) && (gameDataDirectoryStr.trim().length() > 0)) {
+        if (gameDataDirectoryStr != null && gameDataDirectoryStr.trim().length() > 0) {
             try {
                 gameDataDirectory = new File(new URI(gameDataDirectoryStr));
             } catch (URISyntaxException | RuntimeException e) {
@@ -349,7 +349,7 @@ public final class BaseLauncherSettings extends AbstractLauncherSettings {
     @Override
     public synchronized File getGameDirectory() {
         final String gameDirectoryStr = properties.getProperty(PROPERTY_GAME_DIRECTORY);
-        if ((gameDirectoryStr != null) && (gameDirectoryStr.trim().length() > 0)) {
+        if (gameDirectoryStr != null && gameDirectoryStr.trim().length() > 0) {
             try {
                 return new File(new URI(gameDirectoryStr));
             } catch (URISyntaxException | RuntimeException e) {
@@ -362,7 +362,7 @@ public final class BaseLauncherSettings extends AbstractLauncherSettings {
     @Override
     public synchronized File getGameDataDirectory() {
         final String gameDataDirectoryStr = properties.getProperty(PROPERTY_GAME_DATA_DIRECTORY);
-        if ((gameDataDirectoryStr != null) && (gameDataDirectoryStr.trim().length() > 0)) {
+        if (gameDataDirectoryStr != null && gameDataDirectoryStr.trim().length() > 0) {
             try {
                 return new File(new URI(gameDataDirectoryStr));
             } catch (URISyntaxException | RuntimeException e) {
@@ -408,7 +408,7 @@ public final class BaseLauncherSettings extends AbstractLauncherSettings {
 
     @Override
     public synchronized void setLastBuildNumber(Integer lastBuildNumber, GameJob job) {
-        if ((lastBuildNumber != null) && (lastBuildNumber >= job.getMinBuildNumber())) {
+        if (lastBuildNumber != null && lastBuildNumber >= job.getMinBuildNumber()) {
             properties.setProperty(PROPERTY_PREFIX_LAST_BUILD_NUMBER + job.name(), lastBuildNumber.toString());
         } else {
             properties.setProperty(PROPERTY_PREFIX_LAST_BUILD_NUMBER + job.name(), LAST_BUILD_NUMBER_DEFAULT);

--- a/src/main/java/org/terasology/launcher/updater/LauncherUpdater.java
+++ b/src/main/java/org/terasology/launcher/updater/LauncherUpdater.java
@@ -58,12 +58,12 @@ public final class LauncherUpdater {
     public LauncherUpdater(TerasologyLauncherVersionInfo currentVersionInfo) {
         this.currentVersionInfo = currentVersionInfo;
 
-        if ((currentVersionInfo.getBuildNumber() == null) || (currentVersionInfo.getBuildNumber().trim().length() == 0)) {
+        if (currentVersionInfo.getBuildNumber() == null || currentVersionInfo.getBuildNumber().trim().length() == 0) {
             this.currentVersion = "0";
         } else {
             this.currentVersion = currentVersionInfo.getBuildNumber();
         }
-        if ((currentVersionInfo.getJobName() == null) || (currentVersionInfo.getJobName().trim().length() == 0)) {
+        if (currentVersionInfo.getJobName() == null || currentVersionInfo.getJobName().trim().length() == 0) {
             this.jobName = DownloadUtils.TERASOLOGY_LAUNCHER_DEVELOP_JOB_NAME;
         } else {
             this.jobName = currentVersionInfo.getJobName();

--- a/src/main/java/org/terasology/launcher/updater/SelfUpdater.java
+++ b/src/main/java/org/terasology/launcher/updater/SelfUpdater.java
@@ -46,7 +46,7 @@ public final class SelfUpdater {
 
     private static void deleteLauncherContent(File directory) {
         final File[] files = directory.listFiles();
-        if ((files != null) && (files.length > 0)) {
+        if (files != null && files.length > 0) {
             for (File child : files) {
                 if (child.isDirectory()) {
                     if (child.getName().equals("bin") || child.getName().equals("lib") || child.getName().equals("licenses")) {
@@ -101,7 +101,7 @@ public final class SelfUpdater {
 
         logger.info("Running self updater.");
 
-        if ((args == null) || (args.length != 2)) {
+        if (args == null || args.length != 2) {
             logger.error("Two arguments needed!");
             System.exit(1);
         }


### PR DESCRIPTION
Seems #383 did not fix all the warnings for launcher.game so I've added some more fixes. 

There seems to be a bug with slf4j and older versions of PMD which causes the GuardLogStatementJavaUtil warning to be thrown. These warnings should go away when PMD is updated (tested no warnings with PMD 5.5.1).