### PR TITLE
remove underscore from TERASOLOGY_STABLE job name

### DIFF
--- a/src/main/java/org/terasology/launcher/game/GameJob.java
+++ b/src/main/java/org/terasology/launcher/game/GameJob.java
@@ -21,7 +21,7 @@ package org.terasology.launcher.game;
  */
 public enum GameJob {
 
-    TERASOLOGY_STABLE("master", "DistroOmegaRelease", 49, 5, true, false, "RELEASE", "infoHeader1_TerasologyStable",
+    TERASOLOGYSTABLE("master", "DistroOmegaRelease", 49, 5, true, false, "RELEASE", "infoHeader1_TerasologyStable",
                      "settings_game_buildType_TerasologyStable"),
 
     TERASOLOGY("develop", "DistroOmega", 1355, 20, false, false, "DEVELOP", "infoHeader1_Terasology", "settings_game_buildType_Terasology");

--- a/src/main/java/org/terasology/launcher/settings/BaseLauncherSettings.java
+++ b/src/main/java/org/terasology/launcher/settings/BaseLauncherSettings.java
@@ -48,7 +48,7 @@ public final class BaseLauncherSettings extends AbstractLauncherSettings {
     private static final String LAUNCHER_SETTINGS_FILE_NAME = "TerasologyLauncherSettings.properties";
     private static final String COMMENT_SETTINGS = "Terasology Launcher - Settings";
 
-    private static final GameJob JOB_DEFAULT = GameJob.TERASOLOGY_STABLE;
+    private static final GameJob JOB_DEFAULT = GameJob.TERASOLOGYSTABLE;
     private static final JavaHeapSize MAX_HEAP_SIZE_DEFAULT = JavaHeapSize.NOT_USED;
     private static final JavaHeapSize INITIAL_HEAP_SIZE_DEFAULT = JavaHeapSize.NOT_USED;
     private static final String LAST_BUILD_NUMBER_DEFAULT = "";


### PR DESCRIPTION
The job name is used as part of an url when getting the stable build, and the jenkins url does not have the underscore in it.