### PR TITLE
Added tests for FileUtils, BaseLauncherSettings, DirectoryUtils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ dependencies {
 
     // These dependencies are only needed for running tests
     testCompile group: 'junit', name: 'junit', version: '4.11'
+    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
 }
 
 // Set the expected module Java level (can use a higher Java to run, but should not use features from a higher Java)

--- a/src/main/java/org/terasology/launcher/settings/BaseLauncherSettings.java
+++ b/src/main/java/org/terasology/launcher/settings/BaseLauncherSettings.java
@@ -43,36 +43,37 @@ public final class BaseLauncherSettings extends AbstractLauncherSettings {
     public static final String USER_JAVA_PARAMETERS_DEFAULT = "-XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:MaxGCPauseMillis=20 -XX:ParallelGCThreads=10";
     public static final String USER_GAME_PARAMETERS_DEFAULT = "";
 
+    public static final String PROPERTY_LOCALE = "locale";
+    public static final String PROPERTY_JOB = "job";
+    public static final String PROPERTY_MAX_HEAP_SIZE = "maxHeapSize";
+    public static final String PROPERTY_INITIAL_HEAP_SIZE = "initialHeapSize";
+    public static final String PROPERTY_PREFIX_BUILD_VERSION = "buildVersion_";
+    public static final String PROPERTY_PREFIX_LAST_BUILD_NUMBER = "lastBuildNumber_";
+    public static final String PROPERTY_SEARCH_FOR_LAUNCHER_UPDATES = "searchForLauncherUpdates";
+    public static final String PROPERTY_CLOSE_LAUNCHER_AFTER_GAME_START = "closeLauncherAfterGameStart";
+    public static final String PROPERTY_GAME_DIRECTORY = "gameDirectory";
+    public static final String PROPERTY_GAME_DATA_DIRECTORY = "gameDataDirectory";
+    public static final String PROPERTY_SAVE_DOWNLOADED_FILES = "saveDownloadedFiles";
+    public static final String PROPERTY_USER_JAVA_PARAMETERS = "userJavaParameters";
+    public static final String PROPERTY_USER_GAME_PARAMETERS = "userGameParameters";
+    public static final String PROPERTY_LOG_LEVEL = "logLevel";
+
+    public static final GameJob JOB_DEFAULT = GameJob.TerasologyStable;
+    public static final JavaHeapSize MAX_HEAP_SIZE_DEFAULT = JavaHeapSize.NOT_USED;
+    public static final JavaHeapSize INITIAL_HEAP_SIZE_DEFAULT = JavaHeapSize.NOT_USED;
+    public static final String LAST_BUILD_NUMBER_DEFAULT = "";
+    public static final boolean SEARCH_FOR_LAUNCHER_UPDATES_DEFAULT = true;
+    public static final boolean CLOSE_LAUNCHER_AFTER_GAME_START_DEFAULT = true;
+    public static final boolean SAVE_DOWNLOADED_FILES_DEFAULT = false;
+
+    public static final String LAUNCHER_SETTINGS_FILE_NAME = "TerasologyLauncherSettings.properties";
+
     private static final Logger logger = LoggerFactory.getLogger(BaseLauncherSettings.class);
 
-    private static final String LAUNCHER_SETTINGS_FILE_NAME = "TerasologyLauncherSettings.properties";
     private static final String COMMENT_SETTINGS = "Terasology Launcher - Settings";
-
-    private static final GameJob JOB_DEFAULT = GameJob.TerasologyStable;
-    private static final JavaHeapSize MAX_HEAP_SIZE_DEFAULT = JavaHeapSize.NOT_USED;
-    private static final JavaHeapSize INITIAL_HEAP_SIZE_DEFAULT = JavaHeapSize.NOT_USED;
-    private static final String LAST_BUILD_NUMBER_DEFAULT = "";
-    private static final boolean SEARCH_FOR_LAUNCHER_UPDATES_DEFAULT = true;
-    private static final boolean CLOSE_LAUNCHER_AFTER_GAME_START_DEFAULT = true;
-    private static final boolean SAVE_DOWNLOADED_FILES_DEFAULT = false;
 
     private static final String WARN_MSG_INVALID_VALUE = "Invalid value '{}' for the parameter '{}'!";
     private static final LogLevel LOG_LEVEL_DEFAULT = LogLevel.DEFAULT;
-
-    private static final String PROPERTY_LOCALE = "locale";
-    private static final String PROPERTY_JOB = "job";
-    private static final String PROPERTY_MAX_HEAP_SIZE = "maxHeapSize";
-    private static final String PROPERTY_INITIAL_HEAP_SIZE = "initialHeapSize";
-    private static final String PROPERTY_PREFIX_BUILD_VERSION = "buildVersion_";
-    private static final String PROPERTY_PREFIX_LAST_BUILD_NUMBER = "lastBuildNumber_";
-    private static final String PROPERTY_SEARCH_FOR_LAUNCHER_UPDATES = "searchForLauncherUpdates";
-    private static final String PROPERTY_CLOSE_LAUNCHER_AFTER_GAME_START = "closeLauncherAfterGameStart";
-    private static final String PROPERTY_GAME_DIRECTORY = "gameDirectory";
-    private static final String PROPERTY_GAME_DATA_DIRECTORY = "gameDataDirectory";
-    private static final String PROPERTY_SAVE_DOWNLOADED_FILES = "saveDownloadedFiles";
-    private static final String PROPERTY_USER_JAVA_PARAMETERS = "userJavaParameters";
-    private static final String PROPERTY_USER_GAME_PARAMETERS = "userGameParameters";
-    private static final String PROPERTY_LOG_LEVEL = "logLevel";
 
     private final File launcherSettingsFile;
     private final Properties properties;

--- a/src/test/java/org/terasology/launcher/settings/TestBaseLauncherSettings.java
+++ b/src/test/java/org/terasology/launcher/settings/TestBaseLauncherSettings.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.launcher.settings;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.terasology.launcher.game.GameJob;
+import org.terasology.launcher.game.TerasologyGameVersion;
+import org.terasology.launcher.util.JavaHeapSize;
+import org.terasology.launcher.util.Languages;
+import org.terasology.launcher.util.LogLevel;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.net.URI;
+import java.util.Locale;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_CLOSE_LAUNCHER_AFTER_GAME_START;
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_GAME_DATA_DIRECTORY;
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_GAME_DIRECTORY;
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_INITIAL_HEAP_SIZE;
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_JOB;
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_LOCALE;
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_LOG_LEVEL;
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_MAX_HEAP_SIZE;
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_PREFIX_BUILD_VERSION;
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_PREFIX_LAST_BUILD_NUMBER;
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_SAVE_DOWNLOADED_FILES;
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_SEARCH_FOR_LAUNCHER_UPDATES;
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_USER_GAME_PARAMETERS;
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_USER_JAVA_PARAMETERS;
+
+public class TestBaseLauncherSettings {
+    @Rule
+    public TemporaryFolder tempDirectory = new TemporaryFolder();
+
+    private BaseLauncherSettings baseLauncherSettings;
+    private Properties testProperties;
+    private File testPropertiesFile;
+    private File tempLauncherDirectory;
+
+    private String LOCALE;
+    private String JOB;
+    private String MAX_HEAP_SIZE;
+    private String INITIAL_HEAP_SIZE;
+    private String BUILD_VERSION;
+    private String LAST_BUILD_NUMBER;
+    private String SEARCH_FOR_LAUNCHER_UPDATES;
+    private String CLOSE_LAUNCHER_AFTER_GAME_START;
+    private String GAME_DIRECTORY;
+    private String GAME_DATA_DIRECTORY;
+    private String SAVE_DOWNLOADED_FILES;
+    private String USER_JAVA_PARAMETERS;
+    private String USER_GAME_PARAMETERS;
+    private String LOG_LEVEL;
+
+    private void assertPropertiesEqual() throws Exception {
+        assertEquals(baseLauncherSettings.getLocale(), Locale.forLanguageTag(LOCALE));
+        assertEquals(baseLauncherSettings.getJob(), GameJob.valueOf(JOB));
+        assertEquals(baseLauncherSettings.getMaxHeapSize(), JavaHeapSize.valueOf(MAX_HEAP_SIZE));
+        assertEquals(baseLauncherSettings.getInitialHeapSize(), JavaHeapSize.valueOf(INITIAL_HEAP_SIZE));
+        assertEquals(baseLauncherSettings.getBuildVersion(baseLauncherSettings.getJob()), new Integer(BUILD_VERSION));
+        assertEquals(baseLauncherSettings.getLastBuildNumber(baseLauncherSettings.getJob()), new Integer(LAST_BUILD_NUMBER));
+        assertEquals(baseLauncherSettings.isSearchForLauncherUpdates(), Boolean.valueOf(SEARCH_FOR_LAUNCHER_UPDATES));
+        assertEquals(baseLauncherSettings.isCloseLauncherAfterGameStart(), Boolean.valueOf(CLOSE_LAUNCHER_AFTER_GAME_START));
+        assertEquals(baseLauncherSettings.getGameDirectory(), new File(new URI(GAME_DIRECTORY)));
+        assertEquals(baseLauncherSettings.getGameDataDirectory(), new File(new URI(GAME_DATA_DIRECTORY)));
+        assertEquals(baseLauncherSettings.isKeepDownloadedFiles(), Boolean.valueOf(SAVE_DOWNLOADED_FILES));
+        assertEquals(baseLauncherSettings.getUserJavaParameters(), USER_JAVA_PARAMETERS);
+        assertEquals(baseLauncherSettings.getUserGameParameters(), USER_GAME_PARAMETERS);
+        assertEquals(baseLauncherSettings.getLogLevel(), LogLevel.valueOf(LOG_LEVEL));
+    }
+
+    @Before
+    public void setup() throws Exception {
+        tempLauncherDirectory = tempDirectory.newFolder();
+        testPropertiesFile = new File(tempLauncherDirectory, BaseLauncherSettings.LAUNCHER_SETTINGS_FILE_NAME);
+
+        baseLauncherSettings = new BaseLauncherSettings(tempLauncherDirectory);
+    }
+
+    @Test
+    public void testInitWithValues() throws Exception {
+        //initialise properties with sample values
+        LOCALE = "en";
+        JOB = "TerasologyStable";
+        MAX_HEAP_SIZE = "GB_2_5";
+        INITIAL_HEAP_SIZE = "GB_1_5";
+        BUILD_VERSION = String.valueOf(GameJob.valueOf(JOB).getMinBuildNumber() + 1);
+        LAST_BUILD_NUMBER = String.valueOf(GameJob.valueOf(JOB).getMinBuildNumber());
+        SEARCH_FOR_LAUNCHER_UPDATES = "false";
+        CLOSE_LAUNCHER_AFTER_GAME_START = "false";
+        GAME_DIRECTORY = tempDirectory.newFolder().toURI().toString();
+        GAME_DATA_DIRECTORY = tempDirectory.newFolder().toURI().toString();
+        SAVE_DOWNLOADED_FILES = "false";
+        USER_JAVA_PARAMETERS = "-XXnoSystemGC";
+        USER_GAME_PARAMETERS = "-headless";
+        LOG_LEVEL = "DEBUG";
+
+        //set properties
+        testProperties = new Properties();
+        testProperties.setProperty(PROPERTY_LOCALE, LOCALE);
+        testProperties.setProperty(PROPERTY_JOB, JOB);
+        testProperties.setProperty(PROPERTY_MAX_HEAP_SIZE, MAX_HEAP_SIZE);
+        testProperties.setProperty(PROPERTY_INITIAL_HEAP_SIZE, INITIAL_HEAP_SIZE);
+        testProperties.setProperty(PROPERTY_PREFIX_BUILD_VERSION + JOB, BUILD_VERSION);
+        testProperties.setProperty(PROPERTY_PREFIX_LAST_BUILD_NUMBER + JOB, LAST_BUILD_NUMBER);
+        testProperties.setProperty(PROPERTY_SEARCH_FOR_LAUNCHER_UPDATES, SEARCH_FOR_LAUNCHER_UPDATES);
+        testProperties.setProperty(PROPERTY_CLOSE_LAUNCHER_AFTER_GAME_START, CLOSE_LAUNCHER_AFTER_GAME_START);
+        testProperties.setProperty(PROPERTY_GAME_DIRECTORY, GAME_DIRECTORY);
+        testProperties.setProperty(PROPERTY_GAME_DATA_DIRECTORY, GAME_DATA_DIRECTORY);
+        testProperties.setProperty(PROPERTY_SAVE_DOWNLOADED_FILES, SAVE_DOWNLOADED_FILES);
+        testProperties.setProperty(PROPERTY_USER_JAVA_PARAMETERS, USER_JAVA_PARAMETERS);
+        testProperties.setProperty(PROPERTY_USER_GAME_PARAMETERS, USER_GAME_PARAMETERS);
+        testProperties.setProperty(PROPERTY_LOG_LEVEL, LOG_LEVEL);
+
+        //store in properties file
+        testProperties.store(new FileOutputStream(testPropertiesFile), null);
+
+        baseLauncherSettings.load();
+        baseLauncherSettings.init();
+        assertPropertiesEqual();
+    }
+
+    @Test
+    public void testInitDefault() throws Exception {
+        //null properties file
+
+        baseLauncherSettings.load();
+        baseLauncherSettings.init();
+
+        assertEquals(baseLauncherSettings.getLocale(), Languages.DEFAULT_LOCALE);
+        assertEquals(baseLauncherSettings.getJob(), BaseLauncherSettings.JOB_DEFAULT);
+        assertEquals(baseLauncherSettings.getMaxHeapSize(), BaseLauncherSettings.MAX_HEAP_SIZE_DEFAULT);
+        assertEquals(baseLauncherSettings.getInitialHeapSize(), BaseLauncherSettings.INITIAL_HEAP_SIZE_DEFAULT);
+        assertEquals(baseLauncherSettings.getBuildVersion(baseLauncherSettings.getJob()), new Integer(TerasologyGameVersion.BUILD_VERSION_LATEST));
+        assertEquals(baseLauncherSettings.getLastBuildNumber(baseLauncherSettings.getJob()), null);
+        assertEquals(baseLauncherSettings.isSearchForLauncherUpdates(), BaseLauncherSettings.SEARCH_FOR_LAUNCHER_UPDATES_DEFAULT);
+        assertEquals(baseLauncherSettings.isCloseLauncherAfterGameStart(), BaseLauncherSettings.CLOSE_LAUNCHER_AFTER_GAME_START_DEFAULT);
+        assertEquals(baseLauncherSettings.getGameDirectory(), null);
+        assertEquals(baseLauncherSettings.getGameDataDirectory(), null);
+        assertEquals(baseLauncherSettings.isKeepDownloadedFiles(), Boolean.valueOf(SAVE_DOWNLOADED_FILES));
+        assertEquals(baseLauncherSettings.getUserJavaParameters(), BaseLauncherSettings.USER_JAVA_PARAMETERS_DEFAULT);
+        assertEquals(baseLauncherSettings.getUserGameParameters(), BaseLauncherSettings.USER_GAME_PARAMETERS_DEFAULT);
+        assertEquals(baseLauncherSettings.getLogLevel(), LogLevel.DEFAULT);
+    }
+
+    @Test
+    public void testSetters() throws Exception {
+        //re-initialise properties with sample values
+        LOCALE = "fr";
+        JOB = "Terasology";
+        MAX_HEAP_SIZE = "GB_4";
+        INITIAL_HEAP_SIZE = "GB_3";
+        BUILD_VERSION = String.valueOf(GameJob.valueOf(JOB).getMinBuildNumber() + 1);
+        LAST_BUILD_NUMBER = String.valueOf(GameJob.valueOf(JOB).getMinBuildNumber());
+        SEARCH_FOR_LAUNCHER_UPDATES = "true";
+        CLOSE_LAUNCHER_AFTER_GAME_START = "true";
+        GAME_DIRECTORY = tempDirectory.newFolder().toURI().toString();
+        GAME_DATA_DIRECTORY = tempDirectory.newFolder().toURI().toString();
+        SAVE_DOWNLOADED_FILES = "true";
+        USER_JAVA_PARAMETERS = "-XXUseParNewGC -XXUseConcMarkSweepGC";
+        USER_GAME_PARAMETERS = "-noCrashReport";
+        LOG_LEVEL = "INFO";
+
+        //set using setters
+        baseLauncherSettings.setLocale(Locale.forLanguageTag(LOCALE));
+        baseLauncherSettings.setJob(GameJob.valueOf(JOB));
+        baseLauncherSettings.setMaxHeapSize(JavaHeapSize.valueOf(MAX_HEAP_SIZE));
+        baseLauncherSettings.setInitialHeapSize(JavaHeapSize.valueOf(INITIAL_HEAP_SIZE));
+        baseLauncherSettings.setBuildVersion(Integer.parseInt(BUILD_VERSION), GameJob.valueOf(JOB));
+        baseLauncherSettings.setLastBuildNumber(Integer.parseInt(LAST_BUILD_NUMBER), GameJob.valueOf(JOB));
+        baseLauncherSettings.setSearchForLauncherUpdates(Boolean.valueOf(SEARCH_FOR_LAUNCHER_UPDATES));
+        baseLauncherSettings.setCloseLauncherAfterGameStart(Boolean.valueOf(CLOSE_LAUNCHER_AFTER_GAME_START));
+        baseLauncherSettings.setGameDirectory(new File(new URI(GAME_DIRECTORY)));
+        baseLauncherSettings.setGameDataDirectory(new File(new URI(GAME_DATA_DIRECTORY)));
+        baseLauncherSettings.setKeepDownloadedFiles(Boolean.valueOf(SAVE_DOWNLOADED_FILES));
+        baseLauncherSettings.setUserJavaParameters(USER_JAVA_PARAMETERS);
+        baseLauncherSettings.setUserGameParameters(USER_GAME_PARAMETERS);
+        baseLauncherSettings.setLogLevel(LogLevel.valueOf(LOG_LEVEL));
+
+        assertPropertiesEqual();
+    }
+}

--- a/src/test/java/org/terasology/launcher/util/TestDirectoryUtils.java
+++ b/src/test/java/org/terasology/launcher/util/TestDirectoryUtils.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.launcher.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.terasology.launcher.util.DirectoryUtils.checkDirectory;
+import static org.terasology.launcher.util.DirectoryUtils.containsFiles;
+import static org.terasology.launcher.util.DirectoryUtils.containsGameData;
+
+public class TestDirectoryUtils {
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test(expected = IOException.class)
+    public void testCannotCreateDirectory() throws IOException {
+        File directory = mock(File.class);
+        when(directory.exists()).thenReturn(false);
+        when(directory.mkdirs()).thenReturn(false);
+
+        checkDirectory(directory);
+    }
+
+    @Test(expected = IOException.class)
+    public void testNotDirectory() throws IOException {
+        File directory = mock(File.class);
+        when(directory.exists()).thenReturn(true);
+        when(directory.isDirectory()).thenReturn(false);
+
+        checkDirectory(directory);
+    }
+
+    @Test(expected = IOException.class)
+    public void testNoPerms() throws IOException {
+        File directory = mock(File.class);
+        when(directory.canRead()).thenReturn(false);
+        when(directory.canWrite()).thenReturn(false);
+
+        checkDirectory(directory);
+    }
+
+    @Test
+    public void testDirectoryWithFiles() throws IOException {
+        File directory = tempFolder.newFolder();
+        File file = new File(directory, "File");
+        assertTrue(file.createNewFile());
+        assertTrue(containsFiles(directory));
+    }
+
+    @Test
+    public void testEmptyDirectory() throws IOException {
+        File directory = tempFolder.newFolder();
+        assertFalse(containsFiles(directory));
+    }
+
+    @Test
+    public void testGameDirectory() throws IOException {
+        File gameDirectory = tempFolder.newFolder();
+        File savesDirectory = new File(gameDirectory, "saves");
+        File saveFile = new File(savesDirectory, "saveFile");
+        assertTrue(savesDirectory.mkdir());
+        assertTrue(saveFile.createNewFile());
+        assertTrue(containsGameData(gameDirectory));
+    }
+}

--- a/src/test/java/org/terasology/launcher/util/TestFileUtils.java
+++ b/src/test/java/org/terasology/launcher/util/TestFileUtils.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.launcher.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestFileUtils {
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private static final String FILE_NAME = "File";
+    private static final String SAMPLE_TEXT = "Lorem Ipsum";
+
+    @Test
+    public void testDeleteFile() throws IOException {
+        File directory = tempFolder.newFolder();
+        File file = new File(directory, FILE_NAME);
+        assertTrue(file.createNewFile());
+        FileUtils.delete(directory);
+        assertFalse(file.exists());
+        assertFalse(directory.exists());
+    }
+
+    @Test
+    public void testDeleteDirectoryContent() throws IOException {
+        File directory = tempFolder.newFolder();
+        File file = new File(directory, FILE_NAME);
+        assertTrue(file.createNewFile());
+        FileUtils.deleteDirectoryContent(directory);
+        assertFalse(file.exists());
+        assertTrue(directory.exists());
+    }
+
+    @Test
+    public void testCopyFolder() throws IOException {
+        File source = tempFolder.newFolder();
+        File fileInSource = new File(source, FILE_NAME);
+        fileInSource.createNewFile();
+        List<String> text = Arrays.asList(SAMPLE_TEXT);
+        Files.write(fileInSource.toPath(), text, Charset.forName("UTF-8"));
+
+        File destination = tempFolder.newFolder();
+        File fileInDestination = new File(destination, FILE_NAME);
+        FileUtils.copyFolder(source, destination);
+
+        assertTrue(fileInDestination.exists());
+        assertArrayEquals(Files.readAllLines(fileInSource.toPath()).toArray(), Files.readAllLines(fileInDestination.toPath()).toArray());
+    }
+
+//    Currently fails due to inconsistent File.getName() behaviour
+//
+//    @Test
+//    public void testExtract() throws IOException {
+//        File textFile = tempFolder.newFile();
+//        textFile.createNewFile();
+//        List<String> text = Arrays.asList(SAMPLE_TEXT);
+//        Files.write(textFile.toPath(), text, Charset.forName("UTF-8"));
+//
+//        FileInputStream textFileIS = new FileInputStream(textFile);
+//        File zipFile = tempFolder.newFile(FILE_NAME + ".zip");
+//        ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zipFile));
+//        out.putNextEntry(new ZipEntry(textFile.getPath()));
+//        byte[] b = new byte[1024];
+//        int count;
+//        while ((count = textFileIS.read(b)) > 0) {
+//            out.write(b, 0, count);
+//        }
+//        out.close();
+//        textFileIS.close();
+//
+//        File outputDir = tempFolder.newFolder();
+//        FileUtils.extractZipTo(zipFile, outputDir);
+//        File extractedTextFile = new File(outputDir, textFile.getName());
+//        assertArrayEquals(Files.readAllLines(textFile.toPath()).toArray(), Files.readAllLines(extractedTextFile.toPath()).toArray());
+//    }
+
+}


### PR DESCRIPTION
Been working on these for a while 🙂 

## Contains
- TestDirectoryUtils


- TestBaseLauncherSettings

For this, I made some of the private variables in BaseLauncherSettings public as I felt it makes the test much more clearer. Do take a look and see if it's ok.

- TestFileUtils

Refer to the issue below

## How to Test
Run the 3 tests, they should all pass!

## Outstanding before merging
I did spot a issue with `FileUtils` - it calls `File.getName()` on the file in `extractZipTo()` but `getName()` has inconsistent behaviour on different platforms. When I tested it on my machine, it actually returned the full path of the `File` instead of just the name, causing the test to fail. I've commented out this last test for now. I think it might be better if we used `Files.getNameWithoutExtension()` from Guava or `FilenameUtils.getName()` from Apache, what do you think?