### PR TITLE
Add tests for LauncherUpdater and TerasologyGameVersions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,10 @@ dependencies {
     // These dependencies are only needed for running tests
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
+
+    // Don't upgrade either of these until https://github.com/powermock/powermock/issues/717 is resolved
+    testCompile 'org.powermock:powermock-module-junit4:1.6.4'
+    testCompile 'org.powermock:powermock-api-mockito:1.6.4'
 }
 
 // Set the expected module Java level (can use a higher Java to run, but should not use features from a higher Java)

--- a/src/main/java/org/terasology/launcher/game/TerasologyGameVersions.java
+++ b/src/main/java/org/terasology/launcher/game/TerasologyGameVersions.java
@@ -236,6 +236,11 @@ public final class TerasologyGameVersions {
             logger.info("Will try to load Omega build numbers from " + job.getOmegaJobName());
         }
 
+        if (buildNumbers.isEmpty()) {
+            logger.warn("No build numbers provided for job {}. Skipping omega build resolution,", job);
+            return;
+        }
+
         // We more or less redo the original process in looking up the Omega job then later going back in history to map to the engine job
         Integer lastSuccessfulBuildNumber;
         try {

--- a/src/main/java/org/terasology/launcher/version/TerasologyLauncherVersionInfo.java
+++ b/src/main/java/org/terasology/launcher/version/TerasologyLauncherVersionInfo.java
@@ -43,6 +43,8 @@ public final class TerasologyLauncherVersionInfo {
 
     private static TerasologyLauncherVersionInfo instance;
 
+    // Indicates whether this version info is 'empty' (usually indicates that the launcher is being run in a development environment)
+    private final boolean isEmpty;
     private final String buildNumber;
     private final String buildId;
     private final String buildTag;
@@ -62,6 +64,7 @@ public final class TerasologyLauncherVersionInfo {
             properties = loadPropertiesFromInputStream(this.getClass().getResourceAsStream(VERSION_INFO_FILE));
         }
 
+        isEmpty = properties.isEmpty();
         buildNumber = properties.getProperty(BUILD_NUMBER, DEFAULT_VALUE);
         buildId = properties.getProperty(BUILD_ID, DEFAULT_VALUE);
         buildTag = properties.getProperty(BUILD_TAG, DEFAULT_VALUE);
@@ -109,7 +112,12 @@ public final class TerasologyLauncherVersionInfo {
         stringRepresentationBuilder.append(DISPLAY_VERSION);
         stringRepresentationBuilder.append("=");
         stringRepresentationBuilder.append(displayVersion);
+        stringRepresentationBuilder.append(", ");
+        stringRepresentationBuilder.append("isEmpty");
+        stringRepresentationBuilder.append("=");
+        stringRepresentationBuilder.append(isEmpty);
         stringRepresentationBuilder.append("]");
+
         stringRepresentation = stringRepresentationBuilder.toString();
     }
 
@@ -141,6 +149,10 @@ public final class TerasologyLauncherVersionInfo {
         }
 
         return properties;
+    }
+
+    public boolean isEmpty() {
+        return isEmpty;
     }
 
     public String getBuildNumber() {

--- a/src/test/java/org/terasology/launcher/TestingUtils.java
+++ b/src/test/java/org/terasology/launcher/TestingUtils.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.launcher;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+
+import org.junit.Assert;
+import org.powermock.api.mockito.PowerMockito;
+import org.terasology.launcher.game.GameJob;
+import org.terasology.launcher.game.TerasologyGameVersion;
+import org.terasology.launcher.util.DownloadUtils;
+import org.terasology.launcher.util.JobResult;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public class TestingUtils {
+
+    public static void mockBuildVersion(GameJob job, int version) throws Exception {
+        VersionInformation information = new VersionInformation();
+        information.addMapping(job, version);
+        mockBuildVersions(information);
+    }
+
+    public static void mockBuildVersion(String job, int version) throws Exception {
+        VersionInformation information = new VersionInformation();
+        information.addMapping(job, version, version);
+        mockBuildVersions(information);
+    }
+
+    /**
+     * Mocks out various methods in DownloadUtils to respond using the giving job map
+     *
+     * @param buildValues A map from {@link GameJob} names to a map of omega build number to normal build numbers
+     *
+     * @throws Exception
+     */
+    public static void mockBuildVersions(VersionInformation buildValues) throws Exception {
+        PowerMockito.spy(DownloadUtils.class);
+
+        // Cache the greatest normal build number (the values of each sub-map) for each job name to use as the 'latest' value
+        Map<String, Integer> latestBuilds = new HashMap<>();
+        for (Map.Entry<String, Map<Integer, Integer>> entry: buildValues.getMap().entrySet()) {
+            latestBuilds.put(entry.getKey(), Collections.max(entry.getValue().keySet()));
+        }
+
+        PowerMockito.doAnswer((i) -> latestBuilds.get(i.getArgumentAt(0, String.class))).
+                when(DownloadUtils.class,"loadBuildNumberJenkins", anyString(), anyString());
+
+        PowerMockito.doAnswer((i) ->
+                buildValues.hasEntry(i.getArgumentAt(0, String.class), i.getArgumentAt(1, Integer.class)) ? JobResult.SUCCESS : JobResult.NOT_BUILT)
+        .when(DownloadUtils.class, "loadJobResultJenkins", anyString(), anyInt());
+
+        PowerMockito.doReturn(null).when(DownloadUtils.class, "loadChangeLogJenkins", anyString(), anyInt());
+
+        // Omega trigger
+        // This lambda simulates the behavior of an actual Jenkins server, mapping an omega build number to a 'linked' normal build
+        PowerMockito.doAnswer((i) -> {
+            GameJob job = i.getArgumentAt(0, GameJob.class);
+            int omegaBuildNumber = i.getArgumentAt(1, int.class);
+            return buildValues.getNormalFromOmega(job.name(), omegaBuildNumber);
+        }).
+                when(DownloadUtils.class, "loadEngineTriggerJenkins", anyObject(), anyInt());
+    }
+
+    /**
+     * A utility class to hold information for mocking builds.
+     */
+    public static class VersionInformation {
+        // A mapping from a job name (normal or omega) to a mapping of build numbers (of that job's type) to linked build numbers of the opposite type.
+        // For example, 'GameJob.TerasologyStable.name()' would contain a map of 'normal' numbers to 'omega' numbers,
+        // while 'GameJob.TerasologyStable.getOmegaJobName()' would contain a map of 'omega' numbers to 'normal' numbers.
+        private Map<String, Map<Integer, Integer>> buildVersions = new HashMap<>();
+
+        public void addMapping(GameJob job, int normalBuild, Integer omegaBuild) {
+            this.get(job.name()).put(normalBuild, omegaBuild);
+            if (omegaBuild != -1) {
+                this.get(job.getOmegaJobName()).put(omegaBuild, normalBuild);
+            }
+
+        }
+
+        public void addMapping(GameJob job, int normalBuild) {
+            this.addMapping(job, normalBuild, normalBuild);
+        }
+
+        public void addMapping(String job, int normalBuild, Integer omegaBuild) {
+            this.get(job).put(normalBuild, omegaBuild);
+        }
+
+        public int getNormalFromOmega(String job, int omegaBuild) {
+            return this.get(job).getOrDefault(omegaBuild, -1);
+        }
+
+        public boolean hasEntry(String job, int build) {
+            return this.get(job).containsKey(build);
+        }
+
+        public Map<String, Map<Integer, Integer>> getMap() {
+            return this.buildVersions;
+        }
+
+        private Map<Integer, Integer> get(String job) {
+            return this.buildVersions.computeIfAbsent(job, (k) -> new HashMap<>());
+        }
+    }
+
+}

--- a/src/test/java/org/terasology/launcher/game/TestGameVersions.java
+++ b/src/test/java/org/terasology/launcher/game/TestGameVersions.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.launcher.game;
+
+import static org.mockito.Matchers.any;
+import static org.powermock.api.mockito.PowerMockito.spy;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.terasology.launcher.TestingUtils;
+import org.terasology.launcher.settings.BaseLauncherSettings;
+import org.terasology.launcher.util.DownloadUtils;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest( { DownloadUtils.class, TerasologyGameVersions.class })
+public class TestGameVersions {
+
+    // These functions are common assertions, to be used with requireAssertions
+    private static final BiConsumer<TerasologyGameVersion, Integer> REQUIRES_SUCCESSFUL =
+            (version, i) -> Assert.assertEquals(String.format("Build should be successful: %s!", version), true, version.getSuccessful());
+    private static final BiConsumer<TerasologyGameVersion, Integer> REQUIRES_MIN_BUILD_PLUS_ONE =
+            (version, i) -> Assert.assertEquals(String.format("Build number mismatch!: %s", version), version.getJob().getMinBuildNumber() + 1, (long) version.getBuildNumber());
+    private static final BiConsumer<TerasologyGameVersion, Integer> REQUIRES_OMEGA_SAME_NUMBER =
+            (version, i)  -> Assert.assertEquals(String.format("Omega build should have the same number as regular build: %s", version),
+                    version.getBuildNumber(),
+                    version.getOmegaNumber());
+
+
+    // These functions can be used with
+    private static final BiConsumer<TerasologyGameVersion, Integer> REQUIRES_NULL_OMEGA =
+            (version, i) -> Assert.assertNull(String.format("Omega build should not be available: %s!", version), version.getOmegaNumber());
+
+    @Test
+    public void testGetSingleVersion() throws Exception {
+        TerasologyGameVersions gameVersions = this.getGameVersions(true,false);
+        this.loadGameVersions(gameVersions);
+        this.runAssertions(gameVersions, 2, REQUIRES_NULL_OMEGA.andThen(REQUIRES_MIN_BUILD_PLUS_ONE).andThen(REQUIRES_SUCCESSFUL));
+    }
+
+    @Test
+    public void testGetMultipleSequentialVersions() throws Exception {
+        TerasologyGameVersions gameVersions = this.getGameVersions(false,false);
+
+        int minStable = GameJob.TerasologyStable.getMinBuildNumber() + 1;
+        int minUnstable = GameJob.Terasology.getMinBuildNumber() + 1;
+
+        TestingUtils.VersionInformation buildVersions = new TestingUtils.VersionInformation();
+
+        buildVersions.addMapping(GameJob.TerasologyStable, minStable, -1);
+        buildVersions.addMapping(GameJob.TerasologyStable, minStable + 1, -1);
+        buildVersions.addMapping(GameJob.TerasologyStable, minStable + 2, -1);
+
+        buildVersions.addMapping(GameJob.Terasology, minUnstable, -1);
+        buildVersions.addMapping(GameJob.Terasology, minUnstable + 1, -1);
+        buildVersions.addMapping(GameJob.Terasology, minUnstable + 2, -1);
+
+        // Three versions per job, plus the virtual 'latest' version
+        int expectedVersionsPerJob = 4;
+
+        TestingUtils.mockBuildVersions(buildVersions);
+        this.loadGameVersions(gameVersions);
+
+        int[] stableVers = this.getBuildArray(minStable, minStable + 2);
+        int[] unstableVars = this.getBuildArray(minUnstable, minUnstable + 2);
+
+        this.runAssertions(gameVersions, expectedVersionsPerJob, REQUIRES_NULL_OMEGA.andThen(REQUIRES_SUCCESSFUL).andThen((version, i) -> {
+            int[] target = version.getJob() == GameJob.TerasologyStable ? stableVers : unstableVars;
+            Assert.assertEquals(String.format("Build number mismatch: %s", version), target[i], (long) version.getBuildNumber());
+
+        }));
+    }
+
+    @Test
+    public void testGetMultipleNonSequentialVersions() throws Exception {
+        TerasologyGameVersions gameVersions = this.getGameVersions(false,false);
+
+        int minStable = GameJob.TerasologyStable.getMinBuildNumber() + 1;
+        int minUnstable = GameJob.Terasology.getMinBuildNumber() + 1;
+
+        TestingUtils.VersionInformation buildVersions = new TestingUtils.VersionInformation();
+
+        buildVersions.addMapping(GameJob.TerasologyStable, minStable);
+        buildVersions.addMapping(GameJob.TerasologyStable, minStable + 3);
+
+        buildVersions.addMapping(GameJob.Terasology, minUnstable);
+        buildVersions.addMapping(GameJob.Terasology, minUnstable + 3);
+
+        int expectedBuildsPerJob = 5; // Four builds (including the 'filled in' ones) per job, plus the virtual 'latest' version
+
+        Set<Integer> successfulStable = new HashSet<>();
+        successfulStable.addAll(Arrays.asList(minStable, minStable + 3));
+
+        Set<Integer> successfulUnstable = new HashSet<>();
+        successfulUnstable.addAll(Arrays.asList(minUnstable, minUnstable + 3));
+
+        TestingUtils.mockBuildVersions(buildVersions);
+        this.loadGameVersions(gameVersions);
+
+        int[] stableVers = this.getBuildArray(minStable, minStable + 3);
+        int[] unstableVars = this.getBuildArray(minUnstable, minUnstable + 3);
+
+        this.runAssertions(gameVersions, expectedBuildsPerJob, (version, i) -> {
+            boolean isSuccessful = (version.getJob() == GameJob.TerasologyStable ? successfulStable : successfulUnstable).contains(version.getBuildNumber());
+
+            Assert.assertEquals(String.format("Unexpected 'successful' state for version %s", version), isSuccessful, version.getSuccessful());
+            Assert.assertEquals(String.format("Unexpected omega build for version %s", version), isSuccessful ? version.getBuildNumber() : null, version.getOmegaNumber());
+            Assert.assertEquals(String.format("Build number mismatch! 'Gaps' between available builds should be filled %s", version), (version.getJob() == GameJob.TerasologyStable ? stableVers : unstableVars)[i], (long) version.getBuildNumber());
+        });
+    }
+
+    @Test
+    public void testSingleOmegaBuildDetection() throws Exception {
+        TerasologyGameVersions gameVersions = this.getGameVersions(true, true);
+        this.loadGameVersions(gameVersions);
+        this.runAssertions(gameVersions, 2, REQUIRES_OMEGA_SAME_NUMBER.andThen(REQUIRES_MIN_BUILD_PLUS_ONE).andThen(
+                REQUIRES_SUCCESSFUL));
+    }
+
+    private int[] getBuildArray(int start, int stop) {
+        int[] buildArray = new int[(stop-start) + 2]; // add 1 to include the end, and add 1 for the duplicate first build
+        buildArray[0] = stop;  // Duplicate, to account for virtual 'latest' version
+        for (int i = buildArray.length - 1; i > 0; i--) {
+            buildArray[i] = start++;
+        }
+        return buildArray;
+    }
+
+    private void runAssertions(TerasologyGameVersions gameVersions, int expected, BiConsumer<TerasologyGameVersion, Integer> additionalAssertions) {
+        for (GameJob job: GameJob.values()) {
+            List<TerasologyGameVersion> versions = gameVersions.getGameVersionList(job);
+            Assert.assertEquals("Unexpected number of versions for " + job.name(), expected, versions.size());
+
+            TerasologyGameVersion latest = versions.get(0);
+            Assert.assertTrue(String.format("First version is not marked latest: %s", latest), latest.isLatest());
+            Assert.assertEquals("First ('latest') build and second ('real') build do not have the same build number!", latest.getBuildNumber(), versions.get(1).getBuildNumber());
+            for (int i = 0; i < versions.size(); i++) {
+                TerasologyGameVersion version = versions.get(i);
+                Assert.assertEquals(String.format("Build should not be installed: %s!", version), false, version.isInstalled());
+                additionalAssertions.accept(version, i);
+
+                if (version != latest && version.isLatest()) {
+                    Assert.assertNull(String.format("Found more than one latest build: %s %s", latest, version), latest);
+                }
+            }
+        }
+    }
+
+    private void loadGameVersions(TerasologyGameVersions gameVersions) throws Exception {
+        File launcherDir = Files.createTempDirectory("terasology-launcher-dir").toAbsolutePath().toFile();
+        File gameDirectory = Files.createTempDirectory("terasology-game-dir").toAbsolutePath().toFile();
+
+        BaseLauncherSettings settings = new BaseLauncherSettings(launcherDir);
+        settings.init();
+
+        gameVersions.loadGameVersions(settings, launcherDir, gameDirectory);
+    }
+
+    private TerasologyGameVersions getGameVersions(boolean doMapping, boolean omega) throws Exception {
+        spy(TerasologyGameVersions.class);
+
+        TerasologyGameVersions gameVersions = spy(new TerasologyGameVersions());
+
+        if (doMapping) {
+            this.setUpdatesAvailable(true, omega);
+        }
+
+        // We suppress fetching the game version info, so that the test doesn't depend on the network
+        // and is deterministic
+        PowerMockito.doAnswer((i) -> {
+            TerasologyGameVersion version = i.getArgumentAt(0, TerasologyGameVersion.class);
+            version.setGameVersionInfo(TerasologyGameVersionInfo.getEmptyGameVersionInfo());
+            return null;
+        }).when(gameVersions, "loadAndSetGameVersionInfo", any(), any(), any(), any());
+
+        return gameVersions;
+    }
+
+
+    private void setUpdatesAvailable(boolean available, boolean omegaAvailable) throws Exception {
+        int minStable = GameJob.TerasologyStable.getMinBuildNumber() + 1;
+        int minUnstable = GameJob.Terasology.getMinBuildNumber() + 1;
+
+        TestingUtils.VersionInformation buildVersions = new TestingUtils.VersionInformation();
+
+        buildVersions.addMapping(GameJob.TerasologyStable, available ? minStable : 0, omegaAvailable ? minStable : -1);
+        buildVersions.addMapping(GameJob.Terasology, available ? minUnstable : 0, omegaAvailable ? minUnstable : -1);
+
+        TestingUtils.mockBuildVersions(buildVersions);
+    }
+
+}

--- a/src/test/java/org/terasology/launcher/updater/TestLancherUpdater.java
+++ b/src/test/java/org/terasology/launcher/updater/TestLancherUpdater.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.launcher.updater;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.terasology.launcher.TestingUtils;
+import org.terasology.launcher.util.DownloadUtils;
+import org.terasology.launcher.version.TerasologyLauncherVersionInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.Properties;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest( { DownloadUtils.class, LauncherUpdater.class })
+public final class TestLancherUpdater {
+
+    private static String BUILD_NUMBER;
+    private static Constructor<TerasologyLauncherVersionInfo> propertiesConstructor;
+
+    @BeforeClass
+    public static void setupConstructor() throws Exception {
+        propertiesConstructor = TerasologyLauncherVersionInfo.class.getDeclaredConstructor(Properties.class);
+        propertiesConstructor.setAccessible(true);
+
+        Field buildNumber = TerasologyLauncherVersionInfo.class.getDeclaredField("BUILD_NUMBER");
+        buildNumber.setAccessible(true);
+        BUILD_NUMBER = (String) buildNumber.get(null);
+    }
+
+    @Test
+    public void testUpdateUnavailableInDevelopment() throws Exception {
+        // Pass in null to ensure that 'versionInfo.properties' isn't accidentally used
+        TerasologyLauncherVersionInfo info = TerasologyLauncherVersionInfo.loadFromInputStream(null);
+        LauncherUpdater updater = this.getLauncherUpdater(1, info);
+
+        assertFalse("Update should not be available!", updater.updateAvailable());
+    }
+
+    @Test
+    public void testUpdateGreaterVersion() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty(BUILD_NUMBER, "2");
+        TerasologyLauncherVersionInfo info = this.createVersionWithProperties(properties);
+        LauncherUpdater updater = this.getLauncherUpdater(3, info);
+
+        assertTrue("Update should be available!", updater.updateAvailable());
+    }
+
+    @Test
+    public void testUpdateLesserVersion() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty(BUILD_NUMBER, "3");
+        TerasologyLauncherVersionInfo info = this.createVersionWithProperties(properties);
+        LauncherUpdater updater = this.getLauncherUpdater(1, info);
+
+        assertFalse("Update should not be available!", updater.updateAvailable());
+    }
+
+    private TerasologyLauncherVersionInfo createVersionWithProperties(Properties properties) throws Exception {
+        return propertiesConstructor.newInstance(properties);
+    }
+
+    private LauncherUpdater getLauncherUpdater(int buildNum, TerasologyLauncherVersionInfo info) throws Exception {
+        TestingUtils.mockBuildVersion(DownloadUtils.TERASOLOGY_LAUNCHER_DEVELOP_JOB_NAME, buildNum);
+        LauncherUpdater updater = PowerMockito.spy(new LauncherUpdater(info));
+
+        // Simulates version info and changelog being unavailable
+        PowerMockito.doNothing().when(updater, "setNewVersionInfo");
+        PowerMockito.doNothing().when(updater, "setNewChangeLog");
+
+        return updater;
+    }
+}
+


### PR DESCRIPTION
This PR adds unit tests for `LauncherUpdater` and `TerasologyGameVersions`. While there is more behavior that could be tested, I wanted to limit the size of this PR - both to make it easier to review, and to get feedback on some of the change's I've needed to make.

**Added dependencies**

In order to minimize the changes needed to the codebase, I've added `Powermock` as a dependency - the only real alternative is to greatly refactor `DownloadUtils` to allow its methods to be mocked conventionally. As these changes would have no benefit other than avoiding the need for Powermock (it would require making `DownloadUtils` a singleton, or moving making its static methods instance methods of some other class), I didn't think it worthwhile.

**Changes to the codebase**

While Powermock allows the existing codebase to be mocked nearly as-is, I did need to make a few changes to avoid greatly complicating the testing code. Specifically, I moved the uses of `URL#openStream` in `LauncherUpdater#updateAvailable` out into separate methods. This avoids the need to mock out `URL` and/or `URLStream` in order to prevent network requests from being made.

Additionally, I've added an `isEmpty` property `TerasologyLauncherVersionInfo`, which is used to suppress checking for updates when in a development environment. While this could have been PR'd as a separate change, I thought it better to add and test it along with the other methods in `LauncherUpdater`.

**The tests**

For both `TerasologyGameVersions` and `LauncherUpdater`, I've implemented the tests by mocking out various methods in `DownloadUtils`, and testing the behavior given various responses. The code needed to do this is fairly extensive, which I've documented in `TestingUtils`.

**Caveats**

I've opted to leave the constant fields in `TerasologyLauncherVersionInfo` private, and access them with reflection. While this isn't strictly necessary, I didn't see any reason for the fields to be public except to make testing slightly easier Any overhead imposed by reflection is negligible, since it's only used to retrieve the value.