### PR TITLE
Replaced gradle install with gradle installApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Depending on the system it may be necessary to call "./gradlew" instead of "grad
 
 Compile the source code, run tests and build a jar
 
-    gradlew install
+    gradlew installApp
 
 Create a runnable installation (./build/install/TerasologyLauncher/)
 


### PR DESCRIPTION
The "gradle install" task does not seem to exist anymore. I've assumed that the proper replacement is "gradle installApp".