### PR TITLE
Fix zip extractor which wasn't preserving directory structure (fixes #400)

### DIFF
--- a/src/main/java/org/terasology/launcher/util/FileUtils.java
+++ b/src/main/java/org/terasology/launcher/util/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MovingBlocks
+ * Copyright 2017 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/launcher/util/FileUtils.java
+++ b/src/main/java/org/terasology/launcher/util/FileUtils.java
@@ -99,7 +99,7 @@ public final class FileUtils {
             try (ZipInputStream zis = new ZipInputStream(new FileInputStream(archive))) {
                 ZipEntry ze;
                 while ((ze = zis.getNextEntry()) != null) {
-                    File extractedFile = new File(outputLocation, com.google.common.io.Files.getNameWithoutExtension(ze.getName()));
+                    File extractedFile = new File(outputLocation, ze.getName());
                     File extractedDir = extractedFile.getParentFile();
                     if (!extractedDir.exists()) {
                         boolean created = extractedDir.mkdirs();

--- a/src/test/java/org/terasology/launcher/util/TestFileUtils.java
+++ b/src/test/java/org/terasology/launcher/util/TestFileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MovingBlocks
+ * Copyright 2017 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,10 +30,10 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 
 public class TestFileUtils {
     @Rule


### PR DESCRIPTION
This patch fixes issue #400.

It makes the `FileUtils.extractZipTo(File archive, File outputLocation)` method correctly preserve the directory structure when extracting from an archive to a directory.

The test for this method has also been rewritten to test for an archive with a folder inside it; the previous test method, in fact, was passing because it was using a zip containing only a single file, thus not revealing the problem with archives with a more complex directory structure.

I'm not sure if I should remove the dependency on Guava from the Gradle project since it's not used anywhere after removing the call to `com.google.common.io.Files.getNameWithoutExtension`, are there any plans to use it in other parts of the launcher?