### PR TITLE
Removes no longer needed guava dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,6 @@ dependencies {
     compile group: 'net.java.dev.jna', name: 'jna-platform', version: '4.1.0'
     compile group: 'org.terasology', name: 'CrashReporter', version: '1.2.+'
     compile group: 'com.github.rjeschke', name: 'txtmark', version: '0.11'
-    compile group: 'com.google.guava', name: 'guava', version: '20.0'
 
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.2'
 


### PR DESCRIPTION
Dependency was introduced in PR #395 and the only usage removed with
PR #403.