### PR TITLE
Files.list has to be called in a try-with-resources block

### DIFF
--- a/src/main/java/org/terasology/launcher/game/TerasologyGameVersions.java
+++ b/src/main/java/org/terasology/launcher/game/TerasologyGameVersions.java
@@ -654,8 +654,8 @@ public final class TerasologyGameVersions {
             return false;
         }
 
-        try {
-            Optional<Path> foundJar = Files.list(libsDir).filter(f -> f.getFileName().toString().matches(FILE_ENGINE_JAR)).findAny();
+        try (Stream<Path> stream = Files.list(libsDir)) {
+            Optional<Path> foundJar = stream.filter(f -> f.getFileName().toString().matches(FILE_ENGINE_JAR)).findAny();
             if (foundJar.isPresent()) {
                 engineJar = foundJar.get();
             }

--- a/src/main/java/org/terasology/launcher/util/DirectoryUtils.java
+++ b/src/main/java/org/terasology/launcher/util/DirectoryUtils.java
@@ -109,9 +109,8 @@ public final class DirectoryUtils {
             return false;
         }
 
-        try {
-            return Files.list(directory)
-                    .anyMatch(file -> Files.isRegularFile(file) || Files.isDirectory(file) && containsFiles(file));
+        try (Stream<Path> stream = Files.list(directory)) {
+            return stream.anyMatch(file -> Files.isRegularFile(file) || Files.isDirectory(file) && containsFiles(file));
         } catch (IOException e) {
             return false;
         }


### PR DESCRIPTION
While porting the file handling to NIO I missed two calls from `Files.list` which were not in a try-with-resources statement. This can lead to locked files or directory.