### PR TITLE
Limit size of Warning button HBox

### DIFF
--- a/src/main/resources/org/terasology/launcher/views/application.fxml
+++ b/src/main/resources/org/terasology/launcher/views/application.fxml
@@ -119,7 +119,7 @@
                     </Button>
                   </children>
                 </HBox>
-                <HBox alignment="CENTER_LEFT" maxHeight="-Infinity" prefHeight="64.0" spacing="8.0" StackPane.alignment="BOTTOM_LEFT">
+                <HBox alignment="CENTER_LEFT" maxHeight="-Infinity" maxWidth="-Infinity" prefHeight="64.0" prefWidth="64.0" spacing="8.0" StackPane.alignment="BOTTOM_LEFT">
                   <HBox.margin>
                       <Insets left="8.0" />
                   </HBox.margin>


### PR DESCRIPTION
### Contains

When the Warning was added, it was created with its own HBox to correctly place it to the left.
This HBox was overlapping all social buttons, making them unreachable.
As HBox with warning button had defined prefHeight to 64 but no maxWidth, this commit sets this property, effectively preventing the overlap.
Fixes #416

### How to test

1. Check out and run the launcher from latest develop branch.
1. Try to click on the social buttons - notice no animation on them is played when hovering over them and they're not clickable.
1. Checkout and run the game from this PR branch.
1. Try to click on the social buttons - notice animation being played when hovering over them and that the buttons can be clicked.

### Outstanding before merging

Nothing :)

