### PR TITLE
Fix two NPE errors

### DIFF
--- a/src/main/java/org/terasology/launcher/LauncherInitTask.java
+++ b/src/main/java/org/terasology/launcher/LauncherInitTask.java
@@ -226,7 +226,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
             updateMessage(BundleUtils.getLabel("splash_chooseGameDirectory"));
             gameDirectory = GuiUtils.chooseDirectoryDialog(owner, DirectoryUtils.getApplicationDirectory(os, DirectoryUtils.GAME_APPLICATION_DIR_NAME),
                     BundleUtils.getLabel("message_dialog_title_chooseGameDirectory"));
-            if (Files.notExists(gameDirectory)) {
+            if (gameDirectory == null || Files.notExists(gameDirectory)) {
                 logger.info("The new game directory is not approved. The TerasologyLauncher is terminated.");
                 Platform.exit();
             }

--- a/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
@@ -78,8 +78,11 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.ResourceBundle;
 
 public class ApplicationController {
@@ -602,15 +605,20 @@ public class ApplicationController {
     private void updateAboutTab() {
         aboutInfoAccordion.getPanes().clear();
 
-        Collection<URL> files = new ArrayList<>();
-        files.add(BundleUtils.getFXMLUrl(ABOUT, "README.md"));
-        files.add(BundleUtils.getFXMLUrl(ABOUT, "CHANGELOG.md"));
-        files.add(BundleUtils.getFXMLUrl(ABOUT, "CONTRIBUTING.md"));
-        files.add(BundleUtils.getFXMLUrl(ABOUT, "LICENSE"));
+        List<String> fileNames = Arrays.asList("README.md", "CHANGELOG.md", "CONTRIBUTING.md", "LICENSE");
+        Map<String, URL> files = new HashMap<>();
+        for(String filename : fileNames) {
+           files.put(filename, BundleUtils.getFXMLUrl(ABOUT, filename));
+        }
         Charset cs = Charset.forName("UTF-8");
 
-        for (URL url : files) {
+        for (String fileName : files.keySet()) {
             try {
+                URL url = files.get(fileName);
+                if(url == null) { // probably need to run gradlew build, that copies the files to the required place
+                    logger.error("updateAboutTab(): The file {} was not found", fileName);
+                    continue;
+                }
                 int fnameIdx = url.getFile().lastIndexOf('/');
                 int extIdx = url.getFile().lastIndexOf('.');
                 String fname = url.getFile().substring(fnameIdx + 1);
@@ -655,9 +663,9 @@ public class ApplicationController {
 
                 aboutInfoAccordion.getPanes().add(titledPane);
             } catch (MalformedURLException e) {
-                logger.warn("Could not load info file -- {}", url);
+                logger.warn("Could not load info file -- {}", fileName);
             } catch (IOException e) {
-                logger.warn("Failed to parse markdown file {}", url, e);
+                logger.warn("Failed to parse markdown file {}", fileName, e);
             }
 
             if (!aboutInfoAccordion.getPanes().isEmpty()) {

--- a/src/main/java/org/terasology/launcher/util/GuiUtils.java
+++ b/src/main/java/org/terasology/launcher/util/GuiUtils.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import java.awt.Desktop;
 import java.awt.EventQueue;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -84,14 +85,16 @@ public final class GuiUtils {
             directoryChooser.setInitialDirectory(directory.toFile());
             directoryChooser.setTitle(title);
 
-            selected = directoryChooser.showDialog(owner).toPath();
+            File selectedFile = directoryChooser.showDialog(owner);
+            selected = selectedFile != null ? selectedFile.toPath() : null;
         } else {
             final FutureTask<Path> chooseDirectory = new FutureTask<>(() -> {
                 final DirectoryChooser directoryChooser = new DirectoryChooser();
                 directoryChooser.setInitialDirectory(directory.toFile());
                 directoryChooser.setTitle(title);
 
-                return directoryChooser.showDialog(owner).toPath();
+                File selectedFile = directoryChooser.showDialog(owner);
+                return selectedFile != null ? selectedFile.toPath() : null;
             });
 
             Platform.runLater(chooseDirectory);
@@ -104,7 +107,7 @@ public final class GuiUtils {
 
         // directory proposal needs to be deleted if the user chose a different one
         try {
-            if (!Files.isSameFile(directory, selected) && !DirectoryUtils.containsFiles(directory) && !Files.deleteIfExists(directory)) {
+            if (selected != null && !Files.isSameFile(directory, selected) && !DirectoryUtils.containsFiles(directory) && !Files.deleteIfExists(directory)) {
                 logger.warn("Could not delete unused default directory! {}", directory);
             }
         } catch (IOException e) {


### PR DESCRIPTION
Fix two NPE errors.

Pre-requisites: you should not have a Terasology installation directory set for the bug to occur AND a clean installation with cleanIdea and idea BUT not run the build task

* Start the launcher and click on 'cancel' when you are prompted for installation directory. With the fix the launcher will just exit instead of NPE
* Check the about tab. Without gradlew build the files are not copied to the required location, hence NPE when trying to access them. With the fix there will only be a log message about them, and the "about" tab will be empty

The second issue is fixed by running gradlew build, but I think it still should not crash if the files are missing.