### PR TITLE
prevent sleep/hibernate while downloading on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,8 +95,8 @@ repositories {
 // Primary dependencies definition
 dependencies {
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.7'
-    compile group: 'net.java.dev.jna', name: 'jna', version: '4.1.0'
-    compile group: 'net.java.dev.jna', name: 'jna-platform', version: '4.1.0'
+    compile group: 'net.java.dev.jna', name: 'jna', version: '4.5.2'
+    compile group: 'net.java.dev.jna', name: 'jna-platform', version: '4.5.2'
     compile group: 'org.terasology', name: 'CrashReporter', version: '1.2.+'
     compile group: 'com.github.rjeschke', name: 'txtmark', version: '0.11'
 


### PR DESCRIPTION
Windows part of #190 

Prevent screensaver while downloading, Windows only implementation for now.

Upped JNA version to be able to access Kernel32.INSTANCE.SetThreadExecutionState, and put the downloadToFile method into a try-finally block to ensure resetting the thread always happens at the end

# How to test
ONLY FOR WINDOWS USERS: without the Platform.isWindows() check the first step will crash on any other OS!
1. In TerasologyLauncher.java init() method insert this to be the first line:
`Kernel32.INSTANCE.SetThreadExecutionState(WinBase.ES_CONTINUOUS | WinBase.ES_SYSTEM_REQUIRED | WinBase.ES_AWAYMODE_REQUIRED | WinBase.ES_DISPLAY_REQUIRED);`
2. In Windows power options, set the "turn off display" option to 1 minute
3. Start the launcher, wait 1 minute and verify that the display does not turn off