### PR TITLE
Validated launcher settings for 32-bit JVM

### DIFF
--- a/src/main/java/org/terasology/launcher/LauncherInitTask.java
+++ b/src/main/java/org/terasology/launcher/LauncherInitTask.java
@@ -69,7 +69,8 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
             // launcher settings
             final BaseLauncherSettings launcherSettings = getLauncherSettings(launcherDirectory);
 
-            new LauncherSettingsValidator().validate(launcherSettings);
+            // validate the settings
+            LauncherSettingsValidator.validate(launcherSettings);
 
             if (launcherSettings.isSearchForLauncherUpdates()) {
                 final boolean selfUpdaterStarted = checkForLauncherUpdates(downloadDirectory, tempDirectory, launcherSettings.isKeepDownloadedFiles());

--- a/src/main/java/org/terasology/launcher/LauncherInitTask.java
+++ b/src/main/java/org/terasology/launcher/LauncherInitTask.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.launcher.game.GameJob;
 import org.terasology.launcher.game.TerasologyGameVersions;
 import org.terasology.launcher.settings.BaseLauncherSettings;
+import org.terasology.launcher.settings.LauncherSettingsValidator;
 import org.terasology.launcher.updater.LauncherUpdater;
 import org.terasology.launcher.util.BundleUtils;
 import org.terasology.launcher.util.DirectoryUtils;
@@ -67,6 +68,8 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
 
             // launcher settings
             final BaseLauncherSettings launcherSettings = getLauncherSettings(launcherDirectory);
+
+            new LauncherSettingsValidator().validate(launcherSettings);
 
             if (launcherSettings.isSearchForLauncherUpdates()) {
                 final boolean selfUpdaterStarted = checkForLauncherUpdates(downloadDirectory, tempDirectory, launcherSettings.isKeepDownloadedFiles());

--- a/src/main/java/org/terasology/launcher/gui/javafx/SettingsController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/SettingsController.java
@@ -206,7 +206,13 @@ public class SettingsController {
 
         // validate and store changed settings
         try {
-            validator.validate(launcherSettings);
+            if (validator.validateMaxHeapSize(launcherSettings)) {
+                updateMaxHeapSizeBox();
+            }
+            if (validator.validateInitialHeapSize(launcherSettings)) {
+                updateInitialHeapSizeBox();
+            }
+
             launcherSettings.store();
         } catch (IOException e) {
             logger.error("The launcher settings can not be stored! '{}'", launcherSettings.getLauncherSettingsFilePath(), e);

--- a/src/main/java/org/terasology/launcher/gui/javafx/SettingsController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/SettingsController.java
@@ -37,6 +37,7 @@ import org.terasology.launcher.game.TerasologyGameVersion;
 import org.terasology.launcher.game.TerasologyGameVersions;
 import org.terasology.launcher.game.VersionItem;
 import org.terasology.launcher.settings.BaseLauncherSettings;
+import org.terasology.launcher.settings.LauncherSettingsValidator;
 import org.terasology.launcher.util.BundleUtils;
 import org.terasology.launcher.util.DirectoryUtils;
 import org.terasology.launcher.util.GuiUtils;
@@ -60,6 +61,7 @@ public class SettingsController {
     private BaseLauncherSettings launcherSettings;
     private TerasologyGameVersions gameVersions;
 
+    private LauncherSettingsValidator validator;
     private Path gameDirectory;
     private Path gameDataDirectory;
 
@@ -202,8 +204,9 @@ public class SettingsController {
             launcherSettings.setUserGameParameters(userGameParametersField.getText());
         }
 
-        // store changed settings
+        // validate and store changed settings
         try {
+            validator.validate(launcherSettings);
             launcherSettings.store();
         } catch (IOException e) {
             logger.error("The launcher settings can not be stored! '{}'", launcherSettings.getLauncherSettingsFilePath(), e);
@@ -288,6 +291,8 @@ public class SettingsController {
         this.launcherSettings = newLauncherSettings;
         this.gameVersions = newGameVersions;
         this.stage = newStage;
+
+        validator = new LauncherSettingsValidator();
 
         populateJobBox();
         populateHeapSize();

--- a/src/main/java/org/terasology/launcher/gui/javafx/SettingsController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/SettingsController.java
@@ -47,6 +47,7 @@ import org.terasology.launcher.util.LogLevel;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.text.Collator;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
@@ -413,7 +414,13 @@ public class SettingsController {
     private void populateHeapSize() {
         maxHeapSizeBox.getItems().clear();
         initialHeapSizeBox.getItems().clear();
-        for (JavaHeapSize heapSize : JavaHeapSize.values()) {
+
+        // Limit items till 1.5 GB for 32-bit JVM
+        final JavaHeapSize[] heapSizeRange = System.getProperty("os.arch").equals("x86")
+                ? Arrays.copyOfRange(JavaHeapSize.values(), 0, JavaHeapSize.GB_1_5.ordinal() + 1)
+                : JavaHeapSize.values();
+        
+        for (JavaHeapSize heapSize : heapSizeRange) {
             maxHeapSizeBox.getItems().add(heapSize);
             initialHeapSizeBox.getItems().add(heapSize);
         }

--- a/src/main/java/org/terasology/launcher/gui/javafx/SettingsController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/SettingsController.java
@@ -37,7 +37,6 @@ import org.terasology.launcher.game.TerasologyGameVersion;
 import org.terasology.launcher.game.TerasologyGameVersions;
 import org.terasology.launcher.game.VersionItem;
 import org.terasology.launcher.settings.BaseLauncherSettings;
-import org.terasology.launcher.settings.LauncherSettingsValidator;
 import org.terasology.launcher.util.BundleUtils;
 import org.terasology.launcher.util.DirectoryUtils;
 import org.terasology.launcher.util.GuiUtils;
@@ -61,7 +60,6 @@ public class SettingsController {
     private BaseLauncherSettings launcherSettings;
     private TerasologyGameVersions gameVersions;
 
-    private LauncherSettingsValidator validator;
     private Path gameDirectory;
     private Path gameDataDirectory;
 
@@ -204,15 +202,8 @@ public class SettingsController {
             launcherSettings.setUserGameParameters(userGameParametersField.getText());
         }
 
-        // validate and store changed settings
+        // store changed settings
         try {
-            if (validator.validateMaxHeapSize(launcherSettings)) {
-                updateMaxHeapSizeBox();
-            }
-            if (validator.validateInitialHeapSize(launcherSettings)) {
-                updateInitialHeapSizeBox();
-            }
-
             launcherSettings.store();
         } catch (IOException e) {
             logger.error("The launcher settings can not be stored! '{}'", launcherSettings.getLauncherSettingsFilePath(), e);
@@ -297,8 +288,6 @@ public class SettingsController {
         this.launcherSettings = newLauncherSettings;
         this.gameVersions = newGameVersions;
         this.stage = newStage;
-
-        validator = new LauncherSettingsValidator();
 
         populateJobBox();
         populateHeapSize();

--- a/src/main/java/org/terasology/launcher/settings/LauncherSettingsValidator.java
+++ b/src/main/java/org/terasology/launcher/settings/LauncherSettingsValidator.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This file is licensed under the MIT license.
+ * See the LICENSE file in project root for details.
+ */
+
+package org.terasology.launcher.settings;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.launcher.util.JavaHeapSize;
+
+import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_MAX_HEAP_SIZE;
+
+/**
+ * Provides methods to validate launcher settings
+ */
+public class LauncherSettingsValidator {
+    private static final Logger logger = LoggerFactory.getLogger(LauncherSettingsValidator.class);
+
+    public AbstractLauncherSettings validate(BaseLauncherSettings settings) {
+        final JavaHeapSize currentMaxJavaHeapSize = settings.getMaxHeapSize();
+
+        // Checks if JVM is 32 bit
+        if (System.getProperty("sun.arch.data.model").equals("32")
+                && currentMaxJavaHeapSize.compareTo(JavaHeapSize.GB_1_5) > 0) {
+
+            logger.warn("Cannot set '{}' as '{}' for a 32-bit JVM.",
+                    currentMaxJavaHeapSize.getSizeParameter(), PROPERTY_MAX_HEAP_SIZE);
+
+            settings.setMaxHeapSize(JavaHeapSize.GB_1_5);
+
+            logger.warn("Proceeding with '{}' as the '{}'.",
+                    JavaHeapSize.GB_1_5.getSizeParameter(), PROPERTY_MAX_HEAP_SIZE);
+
+            if (settings.getInitialHeapSize().compareTo(currentMaxJavaHeapSize) > 0) {
+                settings.setInitialHeapSize(currentMaxJavaHeapSize);
+            }
+        }
+
+        return settings;
+    }
+}

--- a/src/main/java/org/terasology/launcher/settings/LauncherSettingsValidator.java
+++ b/src/main/java/org/terasology/launcher/settings/LauncherSettingsValidator.java
@@ -33,7 +33,7 @@ import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_MAX
 public class LauncherSettingsValidator {
     private static final Logger logger = LoggerFactory.getLogger(LauncherSettingsValidator.class);
 
-    public AbstractLauncherSettings validate(BaseLauncherSettings settings) {
+    public boolean validateMaxHeapSize(BaseLauncherSettings settings) {
         final JavaHeapSize currentMaxJavaHeapSize = settings.getMaxHeapSize();
 
         // Checks if JVM is 32 bit
@@ -48,11 +48,18 @@ public class LauncherSettingsValidator {
             logger.warn("Proceeding with '{}' as the '{}'.",
                     JavaHeapSize.GB_1_5.getSizeParameter(), PROPERTY_MAX_HEAP_SIZE);
 
-            if (settings.getInitialHeapSize().compareTo(currentMaxJavaHeapSize) > 0) {
-                settings.setInitialHeapSize(currentMaxJavaHeapSize);
-            }
+            return true;
         }
+        return false;
+    }
 
-        return settings;
+    public boolean validateInitialHeapSize(BaseLauncherSettings settings) {
+        final JavaHeapSize currentMaxJavaHeapSize = settings.getMaxHeapSize();
+
+        if (settings.getInitialHeapSize().compareTo(currentMaxJavaHeapSize) > 0) {
+            settings.setInitialHeapSize(currentMaxJavaHeapSize);
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/org/terasology/launcher/settings/LauncherSettingsValidator.java
+++ b/src/main/java/org/terasology/launcher/settings/LauncherSettingsValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MovingBlocks
+ * Copyright 2019 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-/**
- * This file is licensed under the MIT license.
- * See the LICENSE file in project root for details.
- */
-
 package org.terasology.launcher.settings;
 
 import org.slf4j.Logger;
@@ -28,7 +23,7 @@ import org.terasology.launcher.util.JavaHeapSize;
 import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_MAX_HEAP_SIZE;
 
 /**
- * Provides methods to validate launcher settings
+ * Provides methods to validate launcher settings.
  */
 public class LauncherSettingsValidator {
     private static final Logger logger = LoggerFactory.getLogger(LauncherSettingsValidator.class);

--- a/src/main/java/org/terasology/launcher/settings/SettingsValidationRule.java
+++ b/src/main/java/org/terasology/launcher/settings/SettingsValidationRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MovingBlocks
+ * Copyright 2019 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,13 @@
  * limitations under the License.
  */
 
-/**
- * This file is licensed under the MIT license.
- * See the LICENSE file in project root for details.
- */
-
 package org.terasology.launcher.settings;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
- * Provides methods to check settings value and correct invalid values.
+ * Provides methods to check settings values and correct the invalid ones.
  */
 public class SettingsValidationRule {
     private final Predicate<AbstractLauncherSettings> condition;

--- a/src/main/java/org/terasology/launcher/settings/SettingsValidationRule.java
+++ b/src/main/java/org/terasology/launcher/settings/SettingsValidationRule.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This file is licensed under the MIT license.
+ * See the LICENSE file in project root for details.
+ */
+
+package org.terasology.launcher.settings;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Provides methods to check settings value and correct invalid values.
+ */
+public class SettingsValidationRule {
+    private final Predicate<AbstractLauncherSettings> condition;
+    private final String invalidationMessage;
+    private final Consumer<AbstractLauncherSettings> correction;
+
+    public SettingsValidationRule(
+            Predicate<AbstractLauncherSettings> condition,
+            String invalidationMessage,
+            Consumer<AbstractLauncherSettings> correction
+    ) {
+        this.condition = condition;
+        this.invalidationMessage = invalidationMessage;
+        this.correction = correction;
+    }
+
+    public boolean isBrokenBy(AbstractLauncherSettings settings) {
+        return !condition.test(settings);
+    }
+
+    public String getInvalidationMessage() {
+        return invalidationMessage;
+    }
+
+    public void correct(AbstractLauncherSettings settings) {
+        correction.accept(settings);
+    }
+}


### PR DESCRIPTION
### Description
Fixes issue #424. 
It provides a `LauncherSettingsValidator` that validates launcher settings against a set of rules before loading it from the disk and auto-corrects the settings on any violation. It also prevents the user from selecting incorrect settings from the UI.

### How to test
1. First test 
    - Use a 32-bit JVM to start the launcher and open settings
    - Selecting max heap size greater than 1.5GB from the combo box should be impossible now
2. Second test 
    - Open `TerasologyLauncherSettings.properties` before starting the game
    - Set the `maxHeapSize` to `GB_2` or higher and save it
    - Start the laucher from a 32-bit JVM and go to settings
    - The max heap size should be back to 1.5GB in the combo box, with a warning in the log too

### Goals
- [x] Validate launcher settings when loading from disk
- [x] Prevent selecting invalid settings from UI