### PR TITLE
New Settings UI

### DIFF
--- a/src/main/java/org/terasology/launcher/gui/javafx/SettingsController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/SettingsController.java
@@ -24,7 +24,6 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
-import javafx.scene.control.Tab;
 import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
@@ -67,7 +66,7 @@ public class SettingsController {
     private Stage stage;
 
     @FXML
-    private Tab gameTab;
+    private Label gameSettingsTitle;
     @FXML
     private Label maxHeapSizeLabel;
     @FXML
@@ -95,13 +94,13 @@ public class SettingsController {
     @FXML
     private Label logLevelLabel;
     @FXML
-    private Tab launcherTab;
+    private Label launcherSettingsTitle;
     @FXML
     private Label chooseLanguageLabel;
     @FXML
-    private Label closeLauncherLabel;
+    private CheckBox closeAfterStartBox;
     @FXML
-    private Label saveDownloadedFilesLabel;
+    private CheckBox saveDownloadedFilesBox;
     @FXML
     private Label launcherDirectoryLabel;
     @FXML
@@ -111,12 +110,11 @@ public class SettingsController {
     @FXML
     private Button downloadDirectoryOpenButton;
     @FXML
-    private Label searchForUpdatesLabel;
+    private CheckBox searchForUpdatesBox;
     @FXML
     private Button saveSettingsButton;
     @FXML
     private Button cancelSettingsButton;
-
     @FXML
     private ComboBox<JobItem> jobBox;
     @FXML
@@ -128,19 +126,13 @@ public class SettingsController {
     @FXML
     private ComboBox<String> languageBox;
     @FXML
-    private CheckBox saveDownloadedFilesBox;
+    private TextField gameDirectoryPath;
     @FXML
-    private CheckBox searchForUpdatesBox;
+    private TextField gameDataDirectoryPath;
     @FXML
-    private CheckBox closeAfterStartBox;
+    private TextField launcherDirectoryPath;
     @FXML
-    private Label gameDirectoryPath;
-    @FXML
-    private Label gameDataDirectoryPath;
-    @FXML
-    private Label launcherDirectoryPath;
-    @FXML
-    private Label downloadDirectoryPath;
+    private TextField downloadDirectoryPath;
     @FXML
     private TextField userJavaParametersField;
     @FXML
@@ -316,7 +308,7 @@ public class SettingsController {
     private void setLabelStrings() {
         // Game settings
 
-        gameTab.setText(BundleUtils.getLabel("settings_game_title"));
+        gameSettingsTitle.setText(BundleUtils.getLabel("settings_game_title"));
         maxHeapSizeLabel.setText(BundleUtils.getLabel("settings_game_maxHeapSize"));
         initialHeapSizeLabel.setText(BundleUtils.getLabel("settings_game_initialHeapSize"));
         jobLabel.setText(BundleUtils.getLabel("settings_game_job"));
@@ -337,15 +329,15 @@ public class SettingsController {
 
         // Launcher settings
 
-        launcherTab.setText(BundleUtils.getLabel("settings_launcher_title"));
+        launcherSettingsTitle.setText(BundleUtils.getLabel("settings_launcher_title"));
         chooseLanguageLabel.setText(BundleUtils.getLabel("settings_launcher_chooseLanguage"));
-        closeLauncherLabel.setText(BundleUtils.getLabel("settings_launcher_closeLauncherAfterGameStart"));
-        saveDownloadedFilesLabel.setText(BundleUtils.getLabel("settings_launcher_saveDownloadedFiles"));
+        closeAfterStartBox.setText(BundleUtils.getLabel("settings_launcher_closeLauncherAfterGameStart"));
+        saveDownloadedFilesBox.setText(BundleUtils.getLabel("settings_launcher_saveDownloadedFiles"));
         launcherDirectoryLabel.setText(BundleUtils.getLabel("settings_launcher_launcherDirectory"));
         downloadDirectoryLabel.setText(BundleUtils.getLabel("settings_launcher_downloadDirectory"));
         launcherDirectoryOpenButton.setText(BundleUtils.getLabel("settings_launcher_launcherDirectory_open"));
         downloadDirectoryOpenButton.setText(BundleUtils.getLabel("settings_launcher_downloadDirectory_open"));
-        searchForUpdatesLabel.setText(BundleUtils.getLabel("settings_launcher_searchForLauncherUpdates"));
+        searchForUpdatesBox.setText(BundleUtils.getLabel("settings_launcher_searchForLauncherUpdates"));
         saveSettingsButton.setText(BundleUtils.getLabel("settings_save"));
         cancelSettingsButton.setText(BundleUtils.getLabel("settings_cancel"));
     }

--- a/src/main/resources/org/terasology/launcher/views/settings.fxml
+++ b/src/main/resources/org/terasology/launcher/views/settings.fxml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?scenebuilder-preview-i18n-resource ../bundle/LabelsBundle_en.properties?>
-
 <!--
   ~ Copyright 2016 MovingBlocks
   ~
@@ -18,380 +16,158 @@
   ~ limitations under the License.
   -->
 
-<?import javafx.collections.*?>
-<?import javafx.geometry.*?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
-<?import java.lang.*?>
-<?import java.net.URL?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.TitledPane?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.text.Font?>
 
-<AnchorPane id="AnchorPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity"
-            prefHeight="600.0" prefWidth="692.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-            fx:controller="org.terasology.launcher.gui.javafx.SettingsController">
-    <children>
-        <VBox prefHeight="400.0" prefWidth="600.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-              AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-            <children>
-                <TabPane prefHeight="600.0" prefWidth="600.0" tabClosingPolicy="UNAVAILABLE">
-                    <tabs>
-                        <Tab style="" fx:id="gameTab">
-                            <content>
-                                <AnchorPane id="Content" minHeight="0.0" minWidth="0.0" prefHeight="180.0"
-                                            prefWidth="200.0">
-                                    <children>
-                                        <GridPane minHeight="0.0" minWidth="0.0" prefHeight="319.0" prefWidth="568.0"
-                                                  AnchorPane.bottomAnchor="-0.5" AnchorPane.leftAnchor="16.0"
-                                                  AnchorPane.rightAnchor="16.0" AnchorPane.topAnchor="0.5">
-                                            <children>
-                                                <Label fx:id="maxHeapSizeLabel" GridPane.columnIndex="0"
-                                                       GridPane.rowIndex="4"/>
-                                                <Label fx:id="initialHeapSizeLabel" GridPane.columnIndex="0"
-                                                       GridPane.rowIndex="5"/>
-                                                <HBox alignment="CENTER" prefHeight="100.0" prefWidth="200.0"
-                                                      spacing="8.0" GridPane.columnIndex="1" GridPane.rowIndex="4">
-                                                    <children>
-                                                        <ComboBox id="maxHeapSize" fx:id="maxHeapSizeBox"
-                                                                  maxWidth="1.7976931348623157E308"
-                                                                  onAction="#updateMaxHeapSizeBox" HBox.hgrow="ALWAYS">
-                                                            <items>
-                                                                <FXCollections fx:factory="observableArrayList">
-                                                                    <String fx:value="Item 1"/>
-                                                                    <String fx:value="Item 2"/>
-                                                                    <String fx:value="Item 3"/>
-                                                                </FXCollections>
-                                                            </items>
-                                                        </ComboBox>
-                                                    </children>
-                                                    <padding>
-                                                        <Insets left="8.0" right="8.0" fx:id="x1"/>
-                                                    </padding>
-                                                </HBox>
-                                                <HBox alignment="CENTER" prefHeight="100.0" prefWidth="200.0"
-                                                      spacing="8.0" GridPane.columnIndex="1" GridPane.rowIndex="5">
-                                                    <children>
-                                                        <ComboBox id="initialHeapSize" fx:id="initialHeapSizeBox"
-                                                                  maxWidth="1.7976931348623157E308"
-                                                                  onAction="#updateInitialHeapSizeBox"
-                                                                  HBox.hgrow="ALWAYS">
-                                                            <items>
-                                                                <FXCollections fx:factory="observableArrayList">
-                                                                    <String fx:value="Item 1"/>
-                                                                    <String fx:value="Item 2"/>
-                                                                    <String fx:value="Item 3"/>
-                                                                </FXCollections>
-                                                            </items>
-                                                        </ComboBox>
-                                                    </children>
-                                                    <padding>
-                                                        <Insets left="8.0" right="8.0"/>
-                                                    </padding>
-                                                </HBox>
-                                                <Label fx:id="jobLabel" GridPane.columnIndex="0"
-                                                       GridPane.rowIndex="0"/>
-                                                <Label fx:id="buildVersionLabel" GridPane.columnIndex="0"
-                                                       GridPane.rowIndex="1"/>
-                                                <HBox alignment="CENTER" prefHeight="47.0" prefWidth="404.0"
-                                                      spacing="8.0" GridPane.columnIndex="1" GridPane.rowIndex="0">
-                                                    <children>
-                                                        <ComboBox fx:id="jobBox" maxWidth="1.7976931348623157E308"
-                                                                  HBox.hgrow="ALWAYS">
-                                                            <items>
-                                                                <FXCollections fx:factory="observableArrayList">
-                                                                    <String fx:value="Item 1"/>
-                                                                    <String fx:value="Item 2"/>
-                                                                    <String fx:value="Item 3"/>
-                                                                </FXCollections>
-                                                            </items>
-                                                        </ComboBox>
-                                                    </children>
-                                                    <padding>
-                                                        <Insets left="8.0" right="8.0"/>
-                                                    </padding>
-                                                </HBox>
-                                                <HBox alignment="CENTER" prefHeight="100.0" prefWidth="200.0"
-                                                      spacing="8.0" GridPane.columnIndex="1" GridPane.rowIndex="1">
-                                                    <children>
-                                                        <ComboBox fx:id="buildVersionBox"
-                                                                  maxWidth="1.7976931348623157E308" HBox.hgrow="ALWAYS">
-                                                            <items>
-                                                                <FXCollections fx:factory="observableArrayList">
-                                                                    <String fx:value="Item 1"/>
-                                                                    <String fx:value="Item 2"/>
-                                                                    <String fx:value="Item 3"/>
-                                                                </FXCollections>
-                                                            </items>
-                                                        </ComboBox>
-                                                    </children>
-                                                    <padding>
-                                                        <Insets left="8.0" right="8.0"/>
-                                                    </padding>
-                                                </HBox>
-                                                <VBox prefHeight="200.0" prefWidth="100.0" GridPane.columnIndex="1"
-                                                      GridPane.rowIndex="2">
-                                                    <children>
-                                                        <Label fx:id="gameDirectoryPath" graphicTextGap="8.0"
-                                                               maxWidth="1.7976931348623157E308" prefHeight="0.0"
-                                                               prefWidth="388.0" styleClass="boxed" text="Label">
-                                                            <VBox.margin>
-                                                                <Insets/>
-                                                            </VBox.margin>
-                                                        </Label>
-                                                        <HBox alignment="CENTER" prefHeight="63.0" prefWidth="259.0"
-                                                              spacing="8.0">
-                                                            <children>
-                                                                <Button fx:id="gameDirectoryOpenButton"
-                                                                        maxWidth="1.7976931348623157E308"
-                                                                        mnemonicParsing="false"
-                                                                        onAction="#openGameDirectoryAction"
-                                                                        HBox.hgrow="ALWAYS"/>
-                                                                <Button fx:id="gameDirectoryEditButton"
-                                                                        maxWidth="1.7976931348623157E308"
-                                                                        mnemonicParsing="false"
-                                                                        onAction="#editGameDirectoryAction"
-                                                                        HBox.hgrow="ALWAYS"/>
-                                                            </children>
-                                                        </HBox>
-                                                    </children>
-                                                    <GridPane.margin>
-                                                        <Insets left="8.0" right="8.0"/>
-                                                    </GridPane.margin>
-                                                </VBox>
-                                                <VBox prefHeight="200.0" prefWidth="100.0" GridPane.columnIndex="1"
-                                                      GridPane.margin="$x1" GridPane.rowIndex="3">
-                                                    <children>
-                                                        <Label fx:id="gameDataDirectoryPath"
-                                                               maxWidth="1.7976931348623157E308" prefHeight="0.0"
-                                                               prefWidth="388.0" styleClass="boxed" text="Label"
-                                                               VBox.vgrow="ALWAYS"/>
-                                                        <HBox alignment="CENTER" prefHeight="63.0" prefWidth="388.0"
-                                                              spacing="8.0">
-                                                            <children>
-                                                                <Button fx:id="gameDataDirectoryOpenButton"
-                                                                        maxWidth="1.7976931348623157E308"
-                                                                        mnemonicParsing="false"
-                                                                        onAction="#openGameDataDirectoryAction"
-                                                                        HBox.hgrow="ALWAYS"/>
-                                                                <Button fx:id="gameDataDirectoryEditButton"
-                                                                        maxWidth="1.7976931348623157E308"
-                                                                        mnemonicParsing="false"
-                                                                        onAction="#editGameDataDirectoryAction"
-                                                                        HBox.hgrow="ALWAYS"/>
-                                                            </children>
-                                                        </HBox>
-                                                    </children>
-                                                </VBox>
-                                                <VBox prefHeight="200.0" prefWidth="100.0" GridPane.columnIndex="0"
-                                                      GridPane.rowIndex="2">
-                                                    <children>
-                                                        <Label fx:id="gameDirectoryLabel"
-                                                               alignment="TOP_LEFT"/>
-                                                    </children>
-                                                </VBox>
-                                                <VBox prefHeight="200.0" prefWidth="100.0" GridPane.columnIndex="0"
-                                                      GridPane.rowIndex="3">
-                                                    <children>
-                                                        <Label fx:id="gameDataDirectoryLabel"/>
-                                                    </children>
-                                                </VBox>
-                                                <HBox alignment="CENTER" prefHeight="100.0" prefWidth="200.0"
-                                                      GridPane.columnIndex="1" GridPane.rowIndex="6">
-                                                    <children>
-                                                        <TextField fx:id="userJavaParametersField" prefHeight="31.0"
-                                                                   prefWidth="387.0"/>
-                                                    </children>
-                                                </HBox>
-                                                <Label fx:id="javaParametersLabel" GridPane.rowIndex="6"/>
-                                                <Label fx:id="gameParametersLabel" GridPane.rowIndex="7"/>
-                                                <HBox alignment="CENTER" prefHeight="100.0" prefWidth="200.0"
-                                                      GridPane.columnIndex="1" GridPane.rowIndex="7">
-                                                    <children>
-                                                        <TextField fx:id="userGameParametersField" prefHeight="31.0"
-                                                                   prefWidth="389.0"/>
-                                                    </children>
-                                                </HBox>
-                                                <Label fx:id="logLevelLabel" GridPane.rowIndex="8"/>
-                                                <HBox alignment="CENTER" prefHeight="100.0" prefWidth="200.0"
-                                                      GridPane.columnIndex="1" GridPane.rowIndex="8">
-                                                    <children>
-                                                        <ComboBox fx:id="logLevelBox" maxWidth="1.7976931348623157E308"
-                                                                  HBox.hgrow="ALWAYS">
-                                                            <items>
-                                                                <FXCollections fx:factory="observableArrayList">
-                                                                    <String fx:value="Item 1"/>
-                                                                    <String fx:value="Item 2"/>
-                                                                    <String fx:value="Item 3"/>
-                                                                </FXCollections>
-                                                            </items>
-                                                        </ComboBox>
-                                                    </children>
-                                                    <padding>
-                                                        <Insets left="8.0" right="8.0"/>
-                                                    </padding>
-                                                </HBox>
-                                            </children>
-                                            <columnConstraints>
-                                                <ColumnConstraints hgrow="SOMETIMES" maxWidth="-Infinity"
-                                                                   minWidth="10.0" prefWidth="256.0"/>
-                                                <ColumnConstraints hgrow="SOMETIMES" maxWidth="471.0" minWidth="10.0"
-                                                                   prefWidth="376.0"/>
-                                            </columnConstraints>
-                                            <rowConstraints>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                            </rowConstraints>
-                                        </GridPane>
-                                    </children>
-                                </AnchorPane>
-                            </content>
-                        </Tab>
-                        <Tab fx:id="launcherTab">
-                            <content>
-                                <AnchorPane id="Content" minHeight="0.0" minWidth="0.0" prefHeight="180.0"
-                                            prefWidth="200.0">
-                                    <children>
-                                        <GridPane prefHeight="319.0" prefWidth="568.0" AnchorPane.bottomAnchor="0.0"
-                                                  AnchorPane.leftAnchor="16.0" AnchorPane.rightAnchor="16.0"
-                                                  AnchorPane.topAnchor="0.0">
-                                            <children>
-                                                <Label fx:id="chooseLanguageLabel" GridPane.columnIndex="0"
-                                                       GridPane.rowIndex="0"/>
-                                                <Label fx:id="closeLauncherLabel"
-                                                       GridPane.columnIndex="0" GridPane.rowIndex="1"/>
-                                                <Label fx:id="saveDownloadedFilesLabel"
-                                                       GridPane.columnIndex="0" GridPane.rowIndex="3"/>
-                                                <Label fx:id="launcherDirectoryLabel"
-                                                       GridPane.columnIndex="0" GridPane.rowIndex="4"/>
-                                                <Label fx:id="downloadDirectoryLabel"
-                                                       GridPane.columnIndex="0" GridPane.rowIndex="5"/>
-                                                <HBox alignment="CENTER" prefHeight="100.0" prefWidth="200.0"
-                                                      spacing="8.0" GridPane.columnIndex="1" GridPane.rowIndex="0">
-                                                    <children>
-                                                        <ComboBox fx:id="languageBox" maxWidth="1.7976931348623157E308"
-                                                                   HBox.hgrow="ALWAYS">
-                                                            <items>
-                                                                <FXCollections fx:factory="observableArrayList">
-                                                                    <String fx:value="Item 1"/>
-                                                                    <String fx:value="Item 2"/>
-                                                                    <String fx:value="Item 3"/>
-                                                                </FXCollections>
-                                                            </items>
-                                                        </ComboBox>
-                                                    </children>
-                                                    <padding>
-                                                        <Insets left="8.0" right="8.0"/>
-                                                    </padding>
-                                                </HBox>
-                                                <HBox alignment="CENTER_LEFT" prefHeight="100.0" prefWidth="200.0"
-                                                      spacing="8.0" GridPane.columnIndex="1" GridPane.rowIndex="1">
-                                                    <children>
-                                                        <CheckBox id="closeLauncherBox" fx:id="closeAfterStartBox"
-                                                                  contentDisplay="GRAPHIC_ONLY"
-                                                                  mnemonicParsing="false"/>
-                                                    </children>
-                                                    <padding>
-                                                        <Insets left="8.0" right="8.0"/>
-                                                    </padding>
-                                                </HBox>
-                                                <HBox alignment="CENTER_LEFT" prefHeight="100.0" prefWidth="200.0"
-                                                      spacing="8.0" GridPane.columnIndex="1" GridPane.rowIndex="3">
-                                                    <children>
-                                                        <CheckBox fx:id="saveDownloadedFilesBox"
-                                                                  contentDisplay="GRAPHIC_ONLY"
-                                                                  mnemonicParsing="false"/>
-                                                    </children>
-                                                    <padding>
-                                                        <Insets left="8.0" right="8.0"/>
-                                                    </padding>
-                                                </HBox>
-                                                <HBox alignment="CENTER_LEFT" prefHeight="100.0" prefWidth="200.0"
-                                                      spacing="8.0" GridPane.columnIndex="1" GridPane.rowIndex="4">
-                                                    <children>
-                                                        <Label fx:id="launcherDirectoryPath"
-                                                               maxWidth="1.7976931348623157E308" styleClass="boxed"
-                                                               text="Label" HBox.hgrow="ALWAYS"/>
-                                                        <Button fx:id="launcherDirectoryOpenButton"
-                                                                maxWidth="-Infinity" minWidth="-Infinity"
-                                                                mnemonicParsing="false"
-                                                                onAction="#openLauncherDirectoryAction"
-                                                                prefWidth="128.0"
-                                                                HBox.hgrow="SOMETIMES"/>
-                                                    </children>
-                                                    <padding>
-                                                        <Insets left="8.0" right="8.0"/>
-                                                    </padding>
-                                                </HBox>
-                                                <HBox alignment="CENTER_LEFT" prefHeight="100.0" prefWidth="200.0"
-                                                      spacing="8.0" GridPane.columnIndex="1" GridPane.rowIndex="5">
-                                                    <children>
-                                                        <Label fx:id="downloadDirectoryPath"
-                                                               maxWidth="1.7976931348623157E308"
-                                                               onDragDetected="#openDownloadDirectoryAction"
-                                                               styleClass="boxed" text="Label" HBox.hgrow="ALWAYS"/>
-                                                        <Button fx:id="downloadDirectoryOpenButton"
-                                                                maxWidth="-Infinity" minWidth="-Infinity"
-                                                                mnemonicParsing="false"
-                                                                onAction="#openDownloadDirectoryAction"
-                                                                prefWidth="128.0"
-                                                                HBox.hgrow="SOMETIMES"/>
-                                                    </children>
-                                                    <padding>
-                                                        <Insets left="8.0" right="8.0"/>
-                                                    </padding>
-                                                </HBox>
-                                                <Label fx:id="searchForUpdatesLabel"
-                                                       GridPane.columnIndex="0" GridPane.rowIndex="2"/>
-                                                <CheckBox fx:id="searchForUpdatesBox" contentDisplay="GRAPHIC_ONLY"
-                                                          graphicTextGap="0.0" mnemonicParsing="false"
-                                                          GridPane.columnIndex="1" GridPane.rowIndex="2">
-                                                    <GridPane.margin>
-                                                        <Insets left="8.0" right="8.0"/>
-                                                    </GridPane.margin>
-                                                </CheckBox>
-                                            </children>
-                                            <columnConstraints>
-                                                <ColumnConstraints hgrow="SOMETIMES" maxWidth="-Infinity"
-                                                                   minWidth="10.0" prefWidth="256.0"/>
-                                                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0"/>
-                                            </columnConstraints>
-                                            <rowConstraints>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                                            </rowConstraints>
-                                        </GridPane>
-                                    </children>
-                                </AnchorPane>
-                            </content>
-                        </Tab>
-                    </tabs>
-                </TabPane>
-                <Separator prefWidth="200.0"/>
-                <HBox alignment="CENTER" prefHeight="100.0" prefWidth="692.0" spacing="64.0" VBox.vgrow="NEVER">
-                    <children>
-                        <Button fx:id="saveSettingsButton" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
-                                onAction="#saveSettingsAction" textAlignment="CENTER" HBox.hgrow="ALWAYS"/>
-                        <Button fx:id="cancelSettingsButton" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
-                                onAction="#cancelSettingsAction" textAlignment="CENTER"
-                                HBox.hgrow="ALWAYS"/>
-                    </children>
-                    <padding>
-                        <Insets left="32.0" right="32.0"/>
-                    </padding>
-                </HBox>
-            </children>
-        </VBox>
-    </children>
-    <stylesheets>
-        <URL value="@settings.css"/>
-    </stylesheets>
-</AnchorPane>
+<StackPane xmlns="http://javafx.com/javafx/8.0.202" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.terasology.launcher.gui.javafx.SettingsController">
+   <children>
+      <VBox prefHeight="600.0" prefWidth="600.0">
+         <children>
+            <ScrollPane fitToWidth="true" VBox.vgrow="ALWAYS">
+               <content>
+                  <GridPane hgap="10.0">
+                    <columnConstraints>
+                      <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" percentWidth="50.0" prefWidth="100.0" />
+                      <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" percentWidth="50.0" prefWidth="100.0" />
+                    </columnConstraints>
+                    <rowConstraints>
+                      <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                      <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                      <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints maxHeight="1.7976931348623157E308" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="40.0" valignment="BOTTOM" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                    </rowConstraints>
+                     <children>
+                        <Label fx:id="gameSettingsTitle" text="Game settings">
+                           <font>
+                              <Font name="System Bold" size="16.0" />
+                           </font>
+                        </Label>
+                        <Label fx:id="jobLabel" text="Build type" GridPane.rowIndex="1" />
+                        <Label fx:id="buildVersionLabel" text="Build version" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                        <ComboBox fx:id="jobBox" prefWidth="150.0" GridPane.rowIndex="2" />
+                        <ComboBox fx:id="buildVersionBox" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                        <Label fx:id="gameDirectoryLabel" text="Installation directory" GridPane.rowIndex="3" />
+                        <Label fx:id="gameDataDirectoryLabel" text="Data directory" GridPane.rowIndex="5" />
+                        <Label fx:id="maxHeapSizeLabel" text="Maximum memory" GridPane.rowIndex="7" />
+                        <Label fx:id="initialHeapSizeLabel" text="Initial memory" GridPane.columnIndex="1" GridPane.rowIndex="7" />
+                        <ComboBox fx:id="maxHeapSizeBox" onAction="#updateMaxHeapSizeBox" prefWidth="150.0" GridPane.rowIndex="8" />
+                        <ComboBox fx:id="initialHeapSizeBox" onAction="#updateInitialHeapSizeBox" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="8" />
+                        <TextField fx:id="gameDirectoryPath" editable="false" GridPane.rowIndex="4" />
+                        <TextField fx:id="gameDataDirectoryPath" editable="false" GridPane.rowIndex="6" />
+                        <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="1" GridPane.rowIndex="4">
+                           <children>
+                              <Button fx:id="gameDirectoryEditButton" mnemonicParsing="false" onAction="#editGameDirectoryAction" text="Browse" />
+                              <Button fx:id="gameDirectoryOpenButton" mnemonicParsing="false" onAction="#openGameDirectoryAction" text="Button" />
+                           </children>
+                        </HBox>
+                        <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="1" GridPane.rowIndex="6">
+                           <children>
+                              <Button fx:id="gameDataDirectoryEditButton" mnemonicParsing="false" onAction="#editGameDataDirectoryAction" text="Browse" />
+                              <Button fx:id="gameDataDirectoryOpenButton" mnemonicParsing="false" onAction="#openGameDataDirectoryAction" text="Button" />
+                           </children>
+                        </HBox>
+                        <TitledPane animated="false" text="Advanced options" GridPane.columnSpan="2147483647" GridPane.rowIndex="9" GridPane.vgrow="SOMETIMES">
+                          <content>
+                            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
+                                 <children>
+                                    <VBox layoutX="231.0" layoutY="-13.0" prefHeight="200.0" prefWidth="100.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                       <children>
+                                          <Label fx:id="javaParametersLabel" text="JVM arguments" />
+                                          <TextField fx:id="userJavaParametersField" maxWidth="300.0" />
+                                          <Label fx:id="gameParametersLabel" text="Game arguments">
+                                             <VBox.margin>
+                                                <Insets top="10.0" />
+                                             </VBox.margin>
+                                          </Label>
+                                          <TextField fx:id="userGameParametersField" maxWidth="300.0" />
+                                          <Label fx:id="logLevelLabel" text="Logging level">
+                                             <VBox.margin>
+                                                <Insets top="10.0" />
+                                             </VBox.margin>
+                                          </Label>
+                                          <ComboBox fx:id="logLevelBox" prefWidth="150.0" />
+                                       </children>
+                                    </VBox>
+                                 </children>
+                              </AnchorPane>
+                          </content>
+                           <GridPane.margin>
+                              <Insets top="15.0" />
+                           </GridPane.margin>
+                        </TitledPane>
+                        <Label fx:id="launcherSettingsTitle" text="Launcher settings" GridPane.rowIndex="10">
+                           <font>
+                              <Font name="System Bold" size="16.0" />
+                           </font>
+                        </Label>
+                        <Label fx:id="chooseLanguageLabel" text="Language" GridPane.rowIndex="11" />
+                        <ComboBox fx:id="languageBox" prefWidth="150.0" GridPane.rowIndex="12" />
+                        <Label fx:id="launcherDirectoryLabel" text="Data directory" GridPane.rowIndex="13" />
+                        <TextField fx:id="launcherDirectoryPath" editable="false" GridPane.rowIndex="14" />
+                        <Button fx:id="launcherDirectoryOpenButton" mnemonicParsing="false" onAction="#openLauncherDirectoryAction" text="Browse" GridPane.columnIndex="1" GridPane.rowIndex="14" />
+                        <Label fx:id="downloadDirectoryLabel" text="Download directory" GridPane.rowIndex="15" />
+                        <Label text="Updates" GridPane.rowIndex="17" />
+                        <Label text="Other" GridPane.rowIndex="20" />
+                        <Button disable="true" mnemonicParsing="false" text="Check now" GridPane.rowIndex="18" />
+                        <Button fx:id="downloadDirectoryOpenButton" mnemonicParsing="false" onAction="#openDownloadDirectoryAction" text="Browse" GridPane.columnIndex="1" GridPane.rowIndex="16" />
+                        <Label text="Last checked on dd/mm/yyyy" GridPane.columnIndex="1" GridPane.rowIndex="18" />
+                        <CheckBox fx:id="searchForUpdatesBox" mnemonicParsing="false" text="Check on startup" GridPane.columnSpan="2147483647" GridPane.rowIndex="19" />
+                        <CheckBox fx:id="closeAfterStartBox" mnemonicParsing="false" text="Close after game starts" GridPane.rowIndex="21" />
+                        <CheckBox fx:id="saveDownloadedFilesBox" mnemonicParsing="false" text="Save downloaded files" GridPane.rowIndex="22" />
+                        <TextField fx:id="downloadDirectoryPath" editable="false" GridPane.rowIndex="16" />
+                     </children>
+                  </GridPane>
+               </content>
+               <padding>
+                  <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+               </padding>
+            </ScrollPane>
+            <HBox alignment="CENTER_RIGHT" maxHeight="-Infinity" minHeight="-Infinity" prefHeight="36.0" spacing="8.0" VBox.vgrow="NEVER">
+               <children>
+                  <Button fx:id="saveSettingsButton" mnemonicParsing="false" onAction="#saveSettingsAction" prefWidth="80.0" text="Save" />
+                  <Button fx:id="cancelSettingsButton" mnemonicParsing="false" onAction="#cancelSettingsAction" prefWidth="80.0" text="Cancel" />
+                  <Button disable="true" mnemonicParsing="false" prefWidth="80.0" text="Reset" />
+               </children>
+               <padding>
+                  <Insets left="8.0" right="8.0" />
+               </padding>
+            </HBox>
+         </children>
+      </VBox>
+      <Pane fx:id="overlay" prefHeight="200.0" prefWidth="200.0" style="-fx-background-color: rgba(189, 195, 199, 0.5);" visible="false" />
+   </children>
+</StackPane>


### PR DESCRIPTION
### Summary
Implements the new Settings menu UI. Fixes #430 

### Testing
Open the launcher and move over straight to the Settings menu. Test the UI, especially the Save and Cancel buttons. It should be able to save the configuration to `TerasologyLauncherSettings.properties`, inside the launcher's data directory. 

### Screenshot
![screenshot](https://user-images.githubusercontent.com/14859252/59575964-503e2b80-90db-11e9-9358-6981f0b37542.png)

