### PR TITLE
Bundles a JRE with the Launcher package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,9 @@ if (project.hasProperty('bundleJre')) {
         doLast {
             unixScript.text = unixScript.text.replaceFirst(/(?s)# Determine the Java.*(?=\R# Increase)/,
                     '# Use bundled JRE\nJAVACMD=\\$APP_HOME/jre/bin/java\n')
-            // TODO: Handle Windows script
+
+            windowsScript.text = windowsScript.text.replaceFirst(/(?s)@rem Find java.*:init/,
+                    '@rem Use bundled JRE\nset JAVA_EXE=' + /%APP_HOME%\\jre\\bin\\java.exe/ + '\n')
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,22 @@ targetCompatibility = 1.8
 
 mainClassName = 'org.terasology.launcher.TerasologyLauncher'
 
+// Bundle JRE (Use gradle argument: -PbundleJre=/path/to/jre)
+if (project.hasProperty('bundleJre')) {
+    applicationDistribution.from("$bundleJre") {
+        into 'jre'
+    }
+
+    startScripts {
+        doLast {
+            unixScript.text = unixScript.text.replaceFirst(/(?s)# Determine the Java.*(?=\R# Increase)/,
+                    '# Use bundled JRE\nJAVACMD=\\$APP_HOME/jre/bin/java\n')
+            // TODO: Handle Windows script
+        }
+    }
+}
+
+
 checkstyle {
     toolVersion = '6.14.1'
     ignoreFailures = true


### PR DESCRIPTION
### Summary
The final launcher distributions now bundle a given JRE. Fixes #438. 

### Testing
You will need a JRE build with JavaFX in it. Download from one of the following vendors:
- [Azul Zulu](https://www.azul.com/downloads/zulu/zulufx/)
- [Bellsoft Liberica](https://bell-sw.com/pages/java-8u212/)
- [Oracle Java](https://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html) (_Proprietary_)

Extract the downloaded files and use `gradlew clean build -PbundleJre=/path/to/jre` to generate the ZIP packages inside `build/distributions`. Try them in any system, it'll execute the bundled JRE only.

### Roadmap
- [x] Add JRE to the generated packages
- [x] Fix *nix startup script
- [x] Fix windows startup script
