### PR TITLE
Makes the game run using the bundled JRE

### DIFF
--- a/src/main/java/org/terasology/launcher/game/GameStarter.java
+++ b/src/main/java/org/terasology/launcher/game/GameStarter.java
@@ -79,7 +79,7 @@ public final class GameStarter {
     private List<String> createProcessParameters(TerasologyGameVersion gameVersion, Path gameDataDirectory, List<String> javaParameters,
                                                  List<String> gameParameters) {
         final List<String> processParameters = new ArrayList<>();
-        processParameters.add("java");
+        processParameters.add(System.getProperty("java.home") + "/bin/java"); // Use the current java
         processParameters.addAll(javaParameters);
         processParameters.add("-jar");
         processParameters.add(gameVersion.getGameJar().getFileName().toString());


### PR DESCRIPTION
### Summary
Uses the launcher's bundled JRE to start the game. Fixes #443. 

### Testing
- Start the game from the launcher
- Go to _Extras_ → _Metrics Menu_ → _System Context_
- Check the details, it should be referring to the bundled JRE