### PR TITLE
Fix test failure due to incorrect locale

### DIFF
--- a/src/test/java/org/terasology/launcher/util/TestLanguages.java
+++ b/src/test/java/org/terasology/launcher/util/TestLanguages.java
@@ -16,6 +16,7 @@
 
 package org.terasology.launcher.util;
 
+import org.junit.AfterClass;
 import org.junit.Test;
 
 import java.util.Locale;
@@ -112,5 +113,10 @@ public final class TestLanguages {
     @Test
     public void testSize() {
         assertEquals(Languages.SUPPORTED_LOCALES.size(), Languages.SETTINGS_LABEL_KEYS.size());
+    }
+
+    @AfterClass
+    public static void resetLanguages() {
+        Languages.init(Languages.DEFAULT_LOCALE.toString());
     }
 }

--- a/src/test/java/org/terasology/launcher/util/TestLanguages.java
+++ b/src/test/java/org/terasology/launcher/util/TestLanguages.java
@@ -60,13 +60,13 @@ public final class TestLanguages {
     }
 
     @Test
-    public void testUpdateWithJapan() {
+    public void testUpdateWithJapanese() {
         Languages.update(Locale.JAPANESE);
         assertSame(Locale.JAPANESE, Languages.getCurrentLocale());
     }
 
     @Test
-    public void testUpdateWithJapanese() {
+    public void testUpdateWithJapan() {
         Languages.update(Languages.DEFAULT_LOCALE);
         Languages.update(Locale.JAPAN);
         assertSame(Languages.DEFAULT_LOCALE, Languages.getCurrentLocale());


### PR DESCRIPTION
### Summary 
The last 13 [TerasologyLauncherPRs](http://jenkins.terasology.org/view/Launcher/job/TerasologyLauncherPRs/) builds have not been stable due to [a test failure](http://jenkins.terasology.org/view/Launcher/job/TerasologyLauncherPRs/114/testReport/), which was caused by an improper state of `Languages.java` before running the test. This PR fixes things by resetting the state of that class after running `TestLanguages.java`. It also fixes some test names in the same class.