### PR TITLE
Add tasks to download vendored JREs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ certum.jks
 
 # Ignore generated Web API sources
 web-api-client/
+
+# Ignore donwloaded JREs
+jres/**

--- a/build.gradle
+++ b/build.gradle
@@ -34,20 +34,19 @@ buildscript {
 }
 
 plugins {
-    id 'java'
-    id 'project-report'
-    id 'idea'
-    id 'eclipse'
     id 'application'
     id 'checkstyle'
-    id 'pmd'
     id 'com.github.spotbugs' version '1.6.9'
-    // TODO: upgrade to latest version (191011: 4.0.0)
-    id 'de.undercouch.download' version '3.4.3'
+    id 'de.undercouch.download' version '3.4.3' // TODO: upgrade to latest version (191011: 4.0.0)
+    id 'eclipse'
+    id 'idea'
+    id 'java'
     id 'org.hidetake.swagger.generator' version '2.18.1'
+    id 'pmd'
+    id 'project-report'
 }
 
-apply from: "./config/gradle/bundles.gradle"
+apply from: "./config/gradle/jre.gradle"
 apply from: "./config/gradle/quality.gradle"
 apply from: "./config/gradle/swagger.gradle"
 apply from: "./config/gradle/environment.gradle"
@@ -102,9 +101,12 @@ ext {
 repositories {
     // Main Maven repo
     mavenCentral()
-    // MovingBlocks Artifactory instance for libs not readily available elsewhere plus our own libs
+    // MovingBlocks Artifactory instance(s) for libs not readily available elsewhere plus our own libs
+    // TODO figure out why we need two URLs here
+    maven { url "http://artifactory.terasology.org/artifactory/virtual-repo-live" }
     maven {
-        url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
+        // our vendored JREs are published to `libs-release-local`
+        url "http://artifactory.terasology.org/artifactory/libs-release-local" 
     }
     jcenter()
 }

--- a/config/gradle/jre.gradle
+++ b/config/gradle/jre.gradle
@@ -1,0 +1,46 @@
+enum Jre {
+    // TODO Use `.tar.gz` on Linux
+    Linux32("zip"),
+    Linux64("zip"),
+    // TODO rename `Mac` to `MacOS` when artifact is renamed: https://github.com/MovingBlocks/TerasologyJRE/pull/5
+    Mac("zip"),
+    Windows32("zip"),
+    Windows64("zip");
+
+    public URL downloadUrl;
+    public File targetArchive;
+
+    Jre(String extension) {
+        String baseUrl = "http://artifactory.terasology.org/artifactory/libs-release-local"
+
+        // TODO can we use gradle dependencies/configurations to download this for the bundling task?
+        // Use vendored JRE from our Artifactory
+        String groupId = "org/terasology/jre/liberica"
+        String artifactId = this.name().toLowerCase()
+        String version = "0.0.1"
+
+        String artifact = "${artifactId}-${version}.${extension}"
+
+        this.downloadUrl = new URL("${baseUrl}/${groupId}/${artifactId}/${version}/${artifact}")
+        this.targetArchive = new File("${artifact}")   
+    }
+}
+
+task fetchJreAll {
+    group "Download"
+    description "Downloads JRE for all platforms"
+}
+
+Jre.each { arch ->
+    def downloadTask = task("fetchJre${arch}", type: Download) {
+        group "Download"
+        description "Download JRE for ${arch}"
+
+        src arch.downloadUrl
+        dest file("${project.projectDir}/jres/${arch.targetArchive}")
+        overwrite false
+        onlyIfModified true
+    }
+
+    fetchJreAll.dependsOn downloadTask
+}


### PR DESCRIPTION
Based on https://github.com/MovingBlocks/TerasologyLauncher/pull/454

Adds tasks to download our vendored JREs from the Artifactory. The goal is to bundle the Launcher with our provided JREs on each release.

- `gradlew fetchJreAll`  fetches all five JREs for Linux32, Linux64, MacOS, Windows32, Windows64 (depends on the architecture-specific tasks, see below)
- `gradlew fetchJre<architecture>` (e.g., `fetchJreWindows64`) fetches only the JRE for the specific architecture

**Note: This is only about downloading the JREs from Artifactory, I did not touch the bundling part (yet).**


