### PR TITLE
Prevent NPEs when choosing a directories and init the Launcher

### DIFF
--- a/src/main/java/org/terasology/launcher/LauncherInitTask.java
+++ b/src/main/java/org/terasology/launcher/LauncherInitTask.java
@@ -230,7 +230,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
             updateMessage(BundleUtils.getLabel("splash_chooseGameDirectory"));
             gameDirectory = GuiUtils.chooseDirectoryDialog(owner, DirectoryUtils.getApplicationDirectory(os, DirectoryUtils.GAME_APPLICATION_DIR_NAME),
                     BundleUtils.getLabel("message_dialog_title_chooseGameDirectory"));
-            if (Files.notExists(gameDirectory)) {
+            if (gameDirectory == null || Files.notExists(gameDirectory)) {
                 logger.info("The new game directory is not approved. The TerasologyLauncher is terminated.");
                 Platform.exit();
             }


### PR DESCRIPTION
- Avoids NPEs in `GuiUtils` and `LauncherInitTaks` similarly to the work
done in #420.  
- Refactor `updateAboutTab` to use Stream API to add markdown files. The
loop over the _About_ files is refactored to use Stream API, which also
makes it easier to a void `null` values.

Both changes are based on PR #420

Closes #420 

Co-authored-by: AvaLanCS <avalancsreg@gmail.com>