### PR TITLE
Remove duplicate game (type and version) selection

### DIFF
--- a/src/main/java/org/terasology/launcher/gui/javafx/SettingsController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/SettingsController.java
@@ -68,10 +68,6 @@ public class SettingsController {
     @FXML
     private Label initialHeapSizeLabel;
     @FXML
-    private Label jobLabel;
-    @FXML
-    private Label buildVersionLabel;
-    @FXML
     private Button gameDirectoryOpenButton;
     @FXML
     private Button gameDirectoryEditButton;
@@ -112,10 +108,6 @@ public class SettingsController {
     @FXML
     private Button cancelSettingsButton;
     @FXML
-    private ComboBox<ApplicationController.PackageItem> jobBox;
-    @FXML
-    private ComboBox<String> buildVersionBox;
-    @FXML
     private ComboBox<JavaHeapSize> maxHeapSizeBox;
     @FXML
     private ComboBox<JavaHeapSize> initialHeapSizeBox;
@@ -143,15 +135,6 @@ public class SettingsController {
 
     @FXML
     protected void saveSettingsAction(ActionEvent event) {
-        // TODO: Clean up
-        // save job
-        //final JobItem jobItem = jobBox.getSelectionModel().getSelectedItem();
-        //launcherSettings.setJob(jobItem.getJob());
-
-        // save build version
-        //final VersionItem versionItem = buildVersionBox.getSelectionModel().getSelectedItem();
-        //launcherSettings.setBuildVersion(versionItem.getVersion(), jobItem.getJob());
-
         // save gameDirectory
         launcherSettings.setGameDirectory(gameDirectory);
 
@@ -280,7 +263,6 @@ public class SettingsController {
         this.stage = newStage;
         this.appController = newAppController;
 
-        populateJobBox();
         populateHeapSize();
         populateLanguageValues();
         populateLanguageIcons();
@@ -309,8 +291,6 @@ public class SettingsController {
         gameSettingsTitle.setText(BundleUtils.getLabel("settings_game_title"));
         maxHeapSizeLabel.setText(BundleUtils.getLabel("settings_game_maxHeapSize"));
         initialHeapSizeLabel.setText(BundleUtils.getLabel("settings_game_initialHeapSize"));
-        jobLabel.setText(BundleUtils.getLabel("settings_game_job"));
-        buildVersionLabel.setText(BundleUtils.getLabel("settings_game_buildVersion"));
         gameDirectoryOpenButton.setText(BundleUtils.getLabel("settings_game_gameDirectory_open"));
         gameDirectoryEditButton.setText(BundleUtils.getLabel("settings_game_gameDirectory_edit"));
         gameDataDirectoryOpenButton.setText(BundleUtils.getLabel("settings_game_gameDataDirectory_open"));
@@ -338,23 +318,6 @@ public class SettingsController {
         searchForUpdatesBox.setText(BundleUtils.getLabel("settings_launcher_searchForLauncherUpdates"));
         saveSettingsButton.setText(BundleUtils.getLabel("settings_save"));
         cancelSettingsButton.setText(BundleUtils.getLabel("settings_cancel"));
-    }
-
-    private void populateJobBox() {
-        final ComboBox<ApplicationController.PackageItem> origJobBox = appController.getJobBox();
-        final ComboBox<String> origVersionBox = appController.getBuildVersionBox();
-
-        jobBox.setItems(origJobBox.getItems());
-        buildVersionBox.setItems(origVersionBox.getItems());
-        jobBox.getSelectionModel().select(origJobBox.getSelectionModel().getSelectedIndex());
-        buildVersionBox.getSelectionModel().select(origVersionBox.getSelectionModel().getSelectedIndex());
-
-        jobBox.selectionModelProperty().bindBidirectional(appController.getJobBox().selectionModelProperty());
-        buildVersionBox.selectionModelProperty().bindBidirectional(appController.getBuildVersionBox().selectionModelProperty());
-        jobBox.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) -> {
-            buildVersionBox.setItems(newVal.getVersionList());
-            buildVersionBox.getSelectionModel().select(0);
-        });
     }
 
     private void populateHeapSize() {

--- a/src/main/resources/org/terasology/launcher/views/settings.fxml
+++ b/src/main/resources/org/terasology/launcher/views/settings.fxml
@@ -47,8 +47,6 @@
                     </columnConstraints>
                     <rowConstraints>
                       <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                      <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                      <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                         <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                         <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                         <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
@@ -76,31 +74,27 @@
                               <Font name="System Bold" size="16.0" />
                            </font>
                         </Label>
-                        <Label fx:id="jobLabel" text="Build type" GridPane.rowIndex="1" />
-                        <Label fx:id="buildVersionLabel" text="Build version" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-                        <ComboBox fx:id="jobBox" prefWidth="150.0" GridPane.rowIndex="2" />
-                        <ComboBox fx:id="buildVersionBox" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="2" />
-                        <Label fx:id="gameDirectoryLabel" text="Installation directory" GridPane.rowIndex="3" />
-                        <Label fx:id="gameDataDirectoryLabel" text="Data directory" GridPane.rowIndex="5" />
-                        <Label fx:id="maxHeapSizeLabel" text="Maximum memory" GridPane.rowIndex="7" />
-                        <Label fx:id="initialHeapSizeLabel" text="Initial memory" GridPane.columnIndex="1" GridPane.rowIndex="7" />
-                        <ComboBox fx:id="maxHeapSizeBox" onAction="#updateMaxHeapSizeBox" prefWidth="150.0" GridPane.rowIndex="8" />
-                        <ComboBox fx:id="initialHeapSizeBox" onAction="#updateInitialHeapSizeBox" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="8" />
-                        <TextField fx:id="gameDirectoryPath" editable="false" GridPane.rowIndex="4" />
-                        <TextField fx:id="gameDataDirectoryPath" editable="false" GridPane.rowIndex="6" />
-                        <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="1" GridPane.rowIndex="4">
+                        <Label fx:id="gameDirectoryLabel" text="Installation directory" GridPane.rowIndex="1" />
+                        <Label fx:id="gameDataDirectoryLabel" text="Data directory" GridPane.rowIndex="3" />
+                        <Label fx:id="maxHeapSizeLabel" text="Maximum memory" GridPane.rowIndex="5" />
+                        <Label fx:id="initialHeapSizeLabel" text="Initial memory" GridPane.columnIndex="1" GridPane.rowIndex="5" />
+                        <ComboBox fx:id="maxHeapSizeBox" onAction="#updateMaxHeapSizeBox" prefWidth="150.0" GridPane.rowIndex="6" />
+                        <ComboBox fx:id="initialHeapSizeBox" onAction="#updateInitialHeapSizeBox" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+                        <TextField fx:id="gameDirectoryPath" editable="false" GridPane.rowIndex="2" />
+                        <TextField fx:id="gameDataDirectoryPath" editable="false" GridPane.rowIndex="4" />
+                        <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="1" GridPane.rowIndex="2">
                            <children>
                               <Button fx:id="gameDirectoryEditButton" mnemonicParsing="false" onAction="#editGameDirectoryAction" text="Browse" />
                               <Button fx:id="gameDirectoryOpenButton" mnemonicParsing="false" onAction="#openGameDirectoryAction" text="Button" />
                            </children>
                         </HBox>
-                        <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="1" GridPane.rowIndex="6">
+                        <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="1" GridPane.rowIndex="4">
                            <children>
                               <Button fx:id="gameDataDirectoryEditButton" mnemonicParsing="false" onAction="#editGameDataDirectoryAction" text="Browse" />
                               <Button fx:id="gameDataDirectoryOpenButton" mnemonicParsing="false" onAction="#openGameDataDirectoryAction" text="Button" />
                            </children>
                         </HBox>
-                        <TitledPane animated="false" text="Advanced options" GridPane.columnSpan="2147483647" GridPane.rowIndex="9" GridPane.vgrow="SOMETIMES">
+                        <TitledPane animated="false" text="Advanced options" GridPane.columnSpan="2147483647" GridPane.rowIndex="7" GridPane.vgrow="SOMETIMES">
                           <content>
                             <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
                                  <children>
@@ -129,26 +123,26 @@
                               <Insets top="15.0" />
                            </GridPane.margin>
                         </TitledPane>
-                        <Label fx:id="launcherSettingsTitle" text="Launcher settings" GridPane.rowIndex="10">
+                        <Label fx:id="launcherSettingsTitle" text="Launcher settings" GridPane.rowIndex="8">
                            <font>
                               <Font name="System Bold" size="16.0" />
                            </font>
                         </Label>
-                        <Label fx:id="chooseLanguageLabel" text="Language" GridPane.rowIndex="11" />
-                        <ComboBox fx:id="languageBox" prefWidth="150.0" GridPane.rowIndex="12" />
-                        <Label fx:id="launcherDirectoryLabel" text="Data directory" GridPane.rowIndex="13" />
-                        <TextField fx:id="launcherDirectoryPath" editable="false" GridPane.rowIndex="14" />
-                        <Button fx:id="launcherDirectoryOpenButton" mnemonicParsing="false" onAction="#openLauncherDirectoryAction" text="Browse" GridPane.columnIndex="1" GridPane.rowIndex="14" />
-                        <Label fx:id="downloadDirectoryLabel" text="Download directory" GridPane.rowIndex="15" />
-                        <Label text="Updates" GridPane.rowIndex="17" />
-                        <Label text="Other" GridPane.rowIndex="20" />
-                        <Button disable="true" mnemonicParsing="false" text="Check now" GridPane.rowIndex="18" />
-                        <Button fx:id="downloadDirectoryOpenButton" mnemonicParsing="false" onAction="#openDownloadDirectoryAction" text="Browse" GridPane.columnIndex="1" GridPane.rowIndex="16" />
-                        <Label text="Last checked on dd/mm/yyyy" GridPane.columnIndex="1" GridPane.rowIndex="18" />
-                        <CheckBox fx:id="searchForUpdatesBox" mnemonicParsing="false" text="Check on startup" GridPane.columnSpan="2147483647" GridPane.rowIndex="19" />
-                        <CheckBox fx:id="closeAfterStartBox" mnemonicParsing="false" text="Close after game starts" GridPane.rowIndex="21" />
-                        <CheckBox fx:id="saveDownloadedFilesBox" mnemonicParsing="false" text="Save downloaded files" GridPane.rowIndex="22" />
-                        <TextField fx:id="downloadDirectoryPath" editable="false" GridPane.rowIndex="16" />
+                        <Label fx:id="chooseLanguageLabel" text="Language" GridPane.rowIndex="9" />
+                        <ComboBox fx:id="languageBox" prefWidth="150.0" GridPane.rowIndex="10" />
+                        <Label fx:id="launcherDirectoryLabel" text="Data directory" GridPane.rowIndex="11" />
+                        <TextField fx:id="launcherDirectoryPath" editable="false" GridPane.rowIndex="12" />
+                        <Button fx:id="launcherDirectoryOpenButton" mnemonicParsing="false" onAction="#openLauncherDirectoryAction" text="Browse" GridPane.columnIndex="1" GridPane.rowIndex="12" />
+                        <Label fx:id="downloadDirectoryLabel" text="Download directory" GridPane.rowIndex="13" />
+                        <Label text="Updates" GridPane.rowIndex="15" />
+                        <Label text="Other" GridPane.rowIndex="18" />
+                        <Button disable="true" mnemonicParsing="false" text="Check now" GridPane.rowIndex="16" />
+                        <Button fx:id="downloadDirectoryOpenButton" mnemonicParsing="false" onAction="#openDownloadDirectoryAction" text="Browse" GridPane.columnIndex="1" GridPane.rowIndex="14" />
+                        <Label text="Last checked on dd/mm/yyyy" GridPane.columnIndex="1" GridPane.rowIndex="16" />
+                        <CheckBox fx:id="searchForUpdatesBox" mnemonicParsing="false" text="Check on startup" GridPane.columnSpan="2147483647" GridPane.rowIndex="17" />
+                        <CheckBox fx:id="closeAfterStartBox" mnemonicParsing="false" text="Close after game starts" GridPane.rowIndex="19" />
+                        <CheckBox fx:id="saveDownloadedFilesBox" mnemonicParsing="false" text="Save downloaded files" GridPane.rowIndex="20" />
+                        <TextField fx:id="downloadDirectoryPath" editable="false" GridPane.rowIndex="14" />
                      </children>
                   </GridPane>
                </content>


### PR DESCRIPTION
The settings menu offered duplicate selection boxes for the game type
and version. This was the only setting duplicated. As this might be
confusing and does not bring any value we remove it for simplicity.

Co-authored-by: jdrueckert <jd.rueckert@googlemail.com>

### How to test

Start the launcher and do the following actions for different versions:
- select arbitrary combination of package type and version
- verify the following are still working (from main UI)
	- download the game
	- start the game
 	- delete the game
- verify that the settings menu looks fine (no game selection anymore).