### PR TITLE
Refactor AboutViewController

### DIFF
--- a/src/main/java/org/terasology/launcher/gui/javafx/AboutViewController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/AboutViewController.java
@@ -56,7 +56,7 @@ public class AboutViewController {
         Stream.of("README.md", "CHANGELOG.md", "CONTRIBUTING.md", "LICENSE")
                 .map(filename -> BundleUtils.getFXMLUrl(ABOUT, filename))
                 .filter(Objects::nonNull)
-                .map(this::getPaneFor)
+                .map(this::createPaneFor)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .forEach(aboutInfoAccordion.getPanes()::add);
@@ -66,8 +66,8 @@ public class AboutViewController {
         }
     }
 
-    private Optional<TitledPane> getPaneFor(URL url) {
-        return getViewFor(url)
+    private Optional<TitledPane> createPaneFor(URL url) {
+        return createViewFor(url)
                 .map(view -> {
                     view.getStylesheets().add(BundleUtils.getFXMLUrl("css_webview").toExternalForm());
                     view.setContextMenuEnabled(false);
@@ -88,7 +88,7 @@ public class AboutViewController {
                 });
     }
 
-    private Optional<WebView> getViewFor(URL url) {
+    private Optional<WebView> createViewFor(URL url) {
         switch (Files.getFileExtension(url.getFile().toLowerCase())) {
             case "md":
             case "markdown":

--- a/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
@@ -621,7 +621,6 @@ public class ApplicationController {
         updateLabels();
         updateTooltipTexts();
         updateChangeLog();
-        aboutViewController.update();
     }
 
     private void updateLabels() {


### PR DESCRIPTION
Both getPaneFor and getViewFor actually create a pane/view for the given URL
and don't simply get it. Therefore, renaming them.
- rename getPaneFor to createPaneFor
- rename getViewFor to createViewFor
- remove aboutViewController update from ApplicationController as it's no
longer needed there

### How to test:
- Start the launcher
- Check that `About` tab is still displayed correctly