### PR TITLE
Fix Checkstyle errors

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -12,7 +12,6 @@
 <suppressions>
     <suppress checks="MethodName" files="Ole32.java"/>
     <suppress checks="MethodName" files="Shell32.java"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="ApplicationController.java"/>
     <suppress checks="ClassDataAbstractionCoupling" files="TerasologyLauncher.java"/>
     <!-- suppress everything for `ApplicationContorller.java` for now -->
     <!-- TODO: remove this suppression -->

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -14,9 +14,9 @@
     <suppress checks="MethodName" files="Shell32.java"/>
     <suppress checks="ClassDataAbstractionCoupling" files="ApplicationController.java"/>
     <suppress checks="ClassDataAbstractionCoupling" files="TerasologyLauncher.java"/>
-    <suppress checks="CyclomaticComplexity" files="ApplicationController.java"/>
-    <suppress checks="NPathComplexity" files="ApplicationController.java"/>
-    <suppress checks="ClassFanOutComplexity" files="ApplicationController.java"/>
+    <!-- suppress everything for `ApplicationContorller.java` for now -->
+    <!-- TODO: remove this suppression -->
+    <suppress checks=".*" files="src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java"/>
     <!-- GameJob is a data container for the given values - reducing their number by coupling some would increase complexity. -->
     <suppress checks="ParameterNumberCheck" files="src/main/java/org/terasology/launcher/game/GameJob.java"/>
 </suppressions>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -3,6 +3,12 @@
         "-//Puppy Crawl//DTD Suppressions 1.1//EN"
         "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
+<!--
+    This file contains suppression rules for Checkstyle checks.
+    Ideally only files that cannot be modified (e.g. third-party code)
+    should be added here. All other violations should be fixed.
+-->
+
 <suppressions>
     <suppress checks="MethodName" files="Ole32.java"/>
     <suppress checks="MethodName" files="Shell32.java"/>
@@ -11,4 +17,6 @@
     <suppress checks="CyclomaticComplexity" files="ApplicationController.java"/>
     <suppress checks="NPathComplexity" files="ApplicationController.java"/>
     <suppress checks="ClassFanOutComplexity" files="ApplicationController.java"/>
+    <!-- GameJob is a data container for the given values - reducing their number by coupling some would increase complexity. -->
+    <suppress checks="ParameterNumberCheck" files="src/main/java/org/terasology/launcher/game/GameJob.java"/>
 </suppressions>

--- a/src/main/java/org/terasology/launcher/gui/javafx/AboutViewController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/AboutViewController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.terasology.launcher.gui.javafx;
 
 import com.github.rjeschke.txtmark.Configuration;

--- a/src/main/java/org/terasology/launcher/gui/javafx/ChangelogViewController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/ChangelogViewController.java
@@ -31,11 +31,11 @@ public class ChangelogViewController {
     private WebView changelogView;
 
     //TODO: change this to a data type the package manager can handle
-    final private Property<TerasologyGameVersion> gameVersion;
+    private final Property<TerasologyGameVersion> gameVersionProperty;
 
     public ChangelogViewController() {
-        this.gameVersion = new SimpleObjectProperty<>();
-        gameVersion.addListener((observableValue, oldVersion, newVersion) -> update(newVersion));
+        this.gameVersionProperty = new SimpleObjectProperty<>();
+        gameVersionProperty.addListener((observableValue, oldVersion, newVersion) -> update(newVersion));
     }
 
     /**
@@ -43,10 +43,10 @@ public class ChangelogViewController {
      * <p>
      * The <b>ChangelogView</b> will update every time the property changes.
      *
-     * @param version property denoting the game version to display the changelog for
+     * @param property property denoting the game version to display the changelog for
      */
-    public void bind(ReadOnlyProperty<TerasologyGameVersion> version) {
-        gameVersion.bind(version);
+    public void bind(ReadOnlyProperty<TerasologyGameVersion> property) {
+        gameVersionProperty.bind(property);
     }
 
     /**

--- a/src/main/java/org/terasology/launcher/gui/javafx/ChangelogViewController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/ChangelogViewController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.terasology.launcher.gui.javafx;
 
 import javafx.beans.property.Property;

--- a/src/main/java/org/terasology/launcher/gui/javafx/FXUtils.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/FXUtils.java
@@ -21,6 +21,9 @@ import javafx.scene.Node;
 import javafx.util.Duration;
 
 public class FXUtils {
+
+    private FXUtils() {}
+
     /**
      * Creates a {@link javafx.animation.ScaleTransition} with the given factor for the specified node element.
      *

--- a/src/main/java/org/terasology/launcher/gui/javafx/FXUtils.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/FXUtils.java
@@ -20,9 +20,9 @@ import javafx.animation.ScaleTransition;
 import javafx.scene.Node;
 import javafx.util.Duration;
 
-public class FXUtils {
+final class FXUtils {
 
-    private FXUtils() {}
+    private FXUtils() { }
 
     /**
      * Creates a {@link javafx.animation.ScaleTransition} with the given factor for the specified node element.
@@ -31,7 +31,7 @@ public class FXUtils {
      * @param node   the target node
      * @return a transition object
      */
-    public static ScaleTransition createScaleTransition(final double factor, final Node node) {
+    static ScaleTransition createScaleTransition(final double factor, final Node node) {
         final ScaleTransition scaleTransition = new ScaleTransition(Duration.millis(200), node);
         scaleTransition.setFromX(node.getScaleX());
         scaleTransition.setFromY(node.getScaleY());

--- a/src/main/java/org/terasology/launcher/gui/javafx/FXUtils.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/FXUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.terasology.launcher.gui.javafx;
 
 import javafx.animation.ScaleTransition;

--- a/src/main/java/org/terasology/launcher/gui/javafx/FooterController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/FooterController.java
@@ -44,10 +44,10 @@ public class FooterController {
     @FXML
     private Label versionInfo;
     private HostServices hostServices;
-    private Property<Optional<Warning>> warning;
+    private Property<Optional<Warning>> warningProperty;
 
     public FooterController() {
-        warning = new SimpleObjectProperty<>(Optional.empty());
+        warningProperty = new SimpleObjectProperty<>(Optional.empty());
     }
 
     private void updateLabels() {
@@ -66,7 +66,7 @@ public class FooterController {
     @FXML
     public void initialize() {
         updateLabels();
-        warning.addListener((value, oldValue, newValue) -> updateWarningButton(newValue));
+        warningProperty.addListener((value, oldValue, newValue) -> updateWarningButton(newValue));
     }
 
     @FXML
@@ -148,7 +148,7 @@ public class FooterController {
         });
     }
 
-    void bind(ReadOnlyProperty<Optional<Warning>> warning) {
-        this.warning.bind(warning);
+    void bind(ReadOnlyProperty<Optional<Warning>> property) {
+        this.warningProperty.bind(property);
     }
 }

--- a/src/main/java/org/terasology/launcher/gui/javafx/FooterController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/FooterController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.terasology.launcher.gui.javafx;
 
 import javafx.animation.Transition;

--- a/src/main/java/org/terasology/launcher/gui/javafx/FooterController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/FooterController.java
@@ -142,7 +142,7 @@ public class FooterController {
     private void updateWarningButton(Optional<Warning> warning) {
         warningButton.setVisible(warning.isPresent());
         warning.ifPresent(w -> {
-            String msg = BundleUtils.getLabel(w.messageKey);
+            String msg = BundleUtils.getLabel(w.getMessageKey());
             warningButton.setTooltip(new Tooltip(msg));
             logger.warn(msg);
         });

--- a/src/main/java/org/terasology/launcher/gui/javafx/LogViewController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/LogViewController.java
@@ -32,7 +32,7 @@ import java.util.Date;
 
 public class LogViewController extends AppenderBase<ILoggingEvent> {
 
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
 
     private final StringBuffer buffer;
 
@@ -78,7 +78,7 @@ public class LogViewController extends AppenderBase<ILoggingEvent> {
         final String message = loggingEvent.getFormattedMessage();
         final LocalDateTime timestamp = timestampFromEvent(loggingEvent);
 
-        buffer.append(String.format("%s | %-5s | ", formatter.format(timestamp), loggingEvent.getLevel()));
+        buffer.append(String.format("%s | %-5s | ", DATE_FORMATTER.format(timestamp), loggingEvent.getLevel()));
         buffer.append(message);
         buffer.append("\n");
     }

--- a/src/main/java/org/terasology/launcher/gui/javafx/Warning.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/Warning.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.terasology.launcher.gui.javafx;
 
 public enum Warning {

--- a/src/main/java/org/terasology/launcher/gui/javafx/Warning.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/Warning.java
@@ -19,9 +19,13 @@ package org.terasology.launcher.gui.javafx;
 public enum Warning {
     LOW_ON_SPACE("message_warning_lowOnSpace");
 
-    public final String messageKey;
+    private final String messageKey;
 
     Warning(String messageKey) {
         this.messageKey = messageKey;
+    }
+
+    public String getMessageKey() {
+        return messageKey;
     }
 }

--- a/src/main/java/org/terasology/launcher/settings/LauncherSettingsValidator.java
+++ b/src/main/java/org/terasology/launcher/settings/LauncherSettingsValidator.java
@@ -19,6 +19,7 @@ package org.terasology.launcher.settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.launcher.util.JavaHeapSize;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -31,16 +32,16 @@ public final class LauncherSettingsValidator {
     private static final List<SettingsValidationRule> RULES = Arrays.asList(
             // Rule for max heap size
             new SettingsValidationRule(
-                    s -> !(System.getProperty("os.arch").equals("x86") && s.getMaxHeapSize().compareTo(JavaHeapSize.GB_1_5) > 0),
-                    "Max heap size cannot be greater than 1.5 GB for a 32-bit JVM",
-                    s -> s.setMaxHeapSize(JavaHeapSize.GB_1_5)
+                s -> !(System.getProperty("os.arch").equals("x86") && s.getMaxHeapSize().compareTo(JavaHeapSize.GB_1_5) > 0),
+                "Max heap size cannot be greater than 1.5 GB for a 32-bit JVM",
+                s -> s.setMaxHeapSize(JavaHeapSize.GB_1_5)
             ),
 
             // Rule for initial heap size
             new SettingsValidationRule(
-                    s -> s.getInitialHeapSize().compareTo(s.getMaxHeapSize()) < 0,
+                s -> s.getInitialHeapSize().compareTo(s.getMaxHeapSize()) < 0,
                     "Initial heap size cannot be greater than max heap size",
-                    s -> s.setInitialHeapSize(s.getMaxHeapSize())
+                s -> s.setInitialHeapSize(s.getMaxHeapSize())
             )
     );
 
@@ -51,7 +52,7 @@ public final class LauncherSettingsValidator {
      * Validates an {@link AbstractLauncherSettings} instance against a list of rules.
      * Also applies a correction to the settings if it breaks any rule.
      *
-     * @param settings  the settings to be validated
+     * @param settings the settings to be validated
      */
     public static void validate(AbstractLauncherSettings settings) {
         for (SettingsValidationRule rule : RULES) {

--- a/src/main/java/org/terasology/launcher/updater/LauncherUpdater.java
+++ b/src/main/java/org/terasology/launcher/updater/LauncherUpdater.java
@@ -200,7 +200,8 @@ public final class LauncherUpdater {
             final URL updateURL = DownloadUtils.createFileDownloadUrlJenkins(jobName, upstreamVersion, DownloadUtils.FILE_TERASOLOGY_LAUNCHER_ZIP);
             logger.trace("Update URL: {}", updateURL);
 
-            final Path downloadedZipFile = downloadDirectory.resolve( jobName + "_" + upstreamVersion + "_" + System.currentTimeMillis() + ".zip");
+            final Path downloadedZipFile =
+                downloadDirectory.resolve(jobName + "_" + upstreamVersion + "_" + System.currentTimeMillis() + ".zip");
             logger.trace("Download ZIP file: {}", downloadedZipFile);
 
             DownloadUtils.downloadToFile(updateURL, downloadedZipFile, new DummyProgressListener());

--- a/src/main/java/org/terasology/launcher/util/DownloadUtils.java
+++ b/src/main/java/org/terasology/launcher/util/DownloadUtils.java
@@ -33,7 +33,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/main/java/org/terasology/launcher/util/FileUtils.java
+++ b/src/main/java/org/terasology/launcher/util/FileUtils.java
@@ -169,6 +169,25 @@ public final class FileUtils {
         }
     }
 
+
+    /**
+     * Checks whether the given path exists and is a readable directory.
+     * 
+     * Will return <code>false</code> if the given path is <code>null</code> or
+     * any of the required checks fails.
+     * 
+     * @param path path to the directory to check (may be null)
+     * @return true if the given path is a directory with read permissions,
+     *         false otherwise
+     */
+    public static boolean isReadableDir(final Path path) {
+        return 
+            path != null 
+                && Files.exists(path) 
+                && Files.isDirectory(path) 
+                && Files.isReadable(path);
+    }
+
     /**
      * Checks if the given path exists, is a directory and can be read and written by the program.
      *

--- a/src/main/java/org/terasology/launcher/util/LauncherDirectoryUtils.java
+++ b/src/main/java/org/terasology/launcher/util/LauncherDirectoryUtils.java
@@ -52,8 +52,7 @@ public final class LauncherDirectoryUtils {
      */
     public static boolean containsGameData(final Path gameInstallationPath) {
         boolean containsGameData = false;
-        if (gameInstallationPath != null && Files.exists(gameInstallationPath) &&
-                Files.isDirectory(gameInstallationPath) && Files.isReadable(gameInstallationPath)) {
+        if (FileUtils.isReadableDir(gameInstallationPath)) {
             try (Stream<Path> stream = Files.list(gameInstallationPath)) {
                 containsGameData = stream.anyMatch(child -> Files.isDirectory(child)
                         && isGameDataDirectoryName(child.getFileName().toString()) && containsFiles(child));

--- a/src/main/java/org/terasology/launcher/util/LauncherManagedDirectory.java
+++ b/src/main/java/org/terasology/launcher/util/LauncherManagedDirectory.java
@@ -31,9 +31,9 @@ public enum LauncherManagedDirectory {
     CACHE(FileUtils::ensureWritableDir),
     DOWNLOAD(FileUtils::ensureWritableDir);
 
-    final private DirectoryCreator[] creators;
-    final private String errorLabel;
-    final private String directoryName;
+    private final DirectoryCreator[] creators;
+    private final String errorLabel;
+    private final String directoryName;
 
     LauncherManagedDirectory(DirectoryCreator... creators) {
         this.creators = creators;
@@ -42,6 +42,8 @@ public enum LauncherManagedDirectory {
     }
 
     /**
+     * The ordered list of {@link DirectoryCreator}s applicable for this directory.
+     *
      * @return ordered list of {@link DirectoryCreator}s which can be used to create/prepare the directory.
      */
     public DirectoryCreator[] getCreators() {

--- a/src/test/java/org/terasology/launcher/game/TestGameVersions.java
+++ b/src/test/java/org/terasology/launcher/game/TestGameVersions.java
@@ -119,11 +119,8 @@ public class TestGameVersions {
 
         int expectedBuildsPerJob = 5; // Four builds (including the 'filled in' ones) per job, plus the virtual 'latest' version
 
-        Set<Integer> successfulStable = new HashSet<>();
-        successfulStable.addAll(Arrays.asList(minStable, minStable + 3));
-
-        Set<Integer> successfulUnstable = new HashSet<>();
-        successfulUnstable.addAll(Arrays.asList(minUnstable, minUnstable + 3));
+        Set<Integer> successfulStable = new HashSet<>(Arrays.asList(minStable, minStable + 3));
+        Set<Integer> successfulUnstable = new HashSet<>(Arrays.asList(minUnstable, minUnstable + 3));
 
         TestingUtils.mockBuildVersions(buildVersions);
         this.loadGameVersions(gameVersions);
@@ -175,14 +172,8 @@ public class TestGameVersions {
                     latest.getBuildNumber(), versions.get(1).getBuildNumber());
             for (int i = 0; i < versions.size(); i++) {
                 TerasologyGameVersion version = versions.get(i);
-                Assert.assertEquals(String.format(
-                        "Build should not be installed: %s!", version),
-                        false, version.isInstalled());
+                Assert.assertFalse(String.format("Build should not be installed: %s!", version), version.isInstalled());
                 additionalAssertions.accept(version, i);
-
-                if (version != latest && version.isLatest()) {
-                    Assert.assertNull(String.format("Found more than one latest build: %s %s", latest, version), latest);
-                }
             }
         }
     }
@@ -217,7 +208,6 @@ public class TestGameVersions {
         return gameVersions;
     }
 
-
     private void setUpdatesAvailable(boolean available, boolean omegaAvailable) throws Exception {
         int minStable = GameJob.TerasologyStable.getMinBuildNumber() + 1;
         int minUnstable = GameJob.Terasology.getMinBuildNumber() + 1;
@@ -229,5 +219,4 @@ public class TestGameVersions {
 
         TestingUtils.mockBuildVersions(buildVersions);
     }
-
 }

--- a/src/test/java/org/terasology/launcher/game/TestGameVersions.java
+++ b/src/test/java/org/terasology/launcher/game/TestGameVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MovingBlocks
+ * Copyright 2019 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,18 +43,24 @@ public class TestGameVersions {
 
     // These functions are common assertions, to be used with requireAssertions
     private static final BiConsumer<TerasologyGameVersion, Integer> REQUIRES_SUCCESSFUL =
-            (version, i) -> Assert.assertEquals(String.format("Build should be successful: %s!", version), true, version.getSuccessful());
+        (version, i) -> Assert.assertEquals(
+                String.format("Build should be successful: %s!", version),
+                true,
+                version.getSuccessful());
     private static final BiConsumer<TerasologyGameVersion, Integer> REQUIRES_MIN_BUILD_PLUS_ONE =
-            (version, i) -> Assert.assertEquals(String.format("Build number mismatch!: %s", version), version.getJob().getMinBuildNumber() + 1, (long) version.getBuildNumber());
+        (version, i) -> Assert.assertEquals(
+                String.format("Build number mismatch!: %s", version),
+                version.getJob().getMinBuildNumber() + 1,
+                (long) version.getBuildNumber());
     private static final BiConsumer<TerasologyGameVersion, Integer> REQUIRES_OMEGA_SAME_NUMBER =
-            (version, i) -> Assert.assertEquals(String.format("Omega build should have the same number as regular build: %s", version),
-                    version.getBuildNumber(),
-                    version.getOmegaNumber());
-
+        (version, i) -> Assert.assertEquals(
+                String.format("Omega build should have the same number as regular build: %s", version),
+                version.getBuildNumber(),
+                version.getOmegaNumber());
 
     // These functions can be used with
     private static final BiConsumer<TerasologyGameVersion, Integer> REQUIRES_NULL_OMEGA =
-            (version, i) -> Assert.assertNull(String.format("Omega build should not be available: %s!", version), version.getOmegaNumber());
+        (version, i) -> Assert.assertNull(String.format("Omega build should not be available: %s!", version), version.getOmegaNumber());
 
     @Test
     public void testGetSingleVersion() throws Exception {
@@ -126,11 +132,18 @@ public class TestGameVersions {
         int[] unstableVars = this.getBuildArray(minUnstable, minUnstable + 3);
 
         this.runAssertions(gameVersions, expectedBuildsPerJob, (version, i) -> {
-            boolean isSuccessful = (version.getJob() == GameJob.TerasologyStable ? successfulStable : successfulUnstable).contains(version.getBuildNumber());
+            boolean isSuccessful =
+                    (version.getJob() == GameJob.TerasologyStable ? successfulStable : successfulUnstable).contains(version.getBuildNumber());
 
-            Assert.assertEquals(String.format("Unexpected 'successful' state for version %s", version), isSuccessful, version.getSuccessful());
-            Assert.assertEquals(String.format("Unexpected omega build for version %s", version), isSuccessful ? version.getBuildNumber() : null, version.getOmegaNumber());
-            Assert.assertEquals(String.format("Build number mismatch! 'Gaps' between available builds should be filled %s", version), (version.getJob() == GameJob.TerasologyStable ? stableVers : unstableVars)[i], (long) version.getBuildNumber());
+            Assert.assertEquals(
+                    String.format("Unexpected 'successful' state for version %s", version),
+                    isSuccessful, version.getSuccessful());
+            Assert.assertEquals(
+                    String.format("Unexpected omega build for version %s", version),
+                    isSuccessful ? version.getBuildNumber() : null, version.getOmegaNumber());
+            Assert.assertEquals(
+                    String.format("Build number mismatch! 'Gaps' between available builds should be filled %s", version),
+                    (version.getJob() == GameJob.TerasologyStable ? stableVers : unstableVars)[i], (long) version.getBuildNumber());
         });
     }
 
@@ -154,11 +167,17 @@ public class TestGameVersions {
             Assert.assertEquals("Unexpected number of versions for " + job.name(), expected, versions.size());
 
             TerasologyGameVersion latest = versions.get(0);
-            Assert.assertTrue(String.format("First version is not marked latest: %s", latest), latest.isLatest());
-            Assert.assertEquals("First ('latest') build and second ('real') build do not have the same build number!", latest.getBuildNumber(), versions.get(1).getBuildNumber());
+            Assert.assertTrue(String.format(
+                    "First version is not marked latest: %s", latest),
+                    latest.isLatest());
+            Assert.assertEquals(
+                    "First ('latest') build and second ('real') build do not have the same build number!",
+                    latest.getBuildNumber(), versions.get(1).getBuildNumber());
             for (int i = 0; i < versions.size(); i++) {
                 TerasologyGameVersion version = versions.get(i);
-                Assert.assertEquals(String.format("Build should not be installed: %s!", version), false, version.isInstalled());
+                Assert.assertEquals(String.format(
+                        "Build should not be installed: %s!", version),
+                        false, version.isInstalled());
                 additionalAssertions.accept(version, i);
 
                 if (version != latest && version.isLatest()) {


### PR DESCRIPTION
In an attempt to utilize static code analysis and code scans again I'm trying to clean up on warnings and errors reported by Checkstyle. Most of them were simple warnings (e.g., bad formatting or wrong order of modifiers). 
Others involved a bit more refactoring, like reducing the complexity in `TerasologyGameVersions`, or trying to reduce the number of arguments/parameters accepted by a method or constructor.

Nothing of this should change semantics and should be save to merge. 

![image](https://user-images.githubusercontent.com/1448874/69468316-ec0b4c00-0d8b-11ea-8d4f-562998a24077.png)
