### PR TITLE
Shows changelog of selected game package

### DIFF
--- a/src/main/java/org/terasology/launcher/gui/javafx/ChangelogViewController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/ChangelogViewController.java
@@ -25,6 +25,8 @@ import javafx.scene.web.WebView;
 import org.terasology.launcher.game.TerasologyGameVersion;
 import org.terasology.launcher.util.BundleUtils;
 
+import java.util.List;
+
 public class ChangelogViewController {
 
     @FXML
@@ -35,7 +37,6 @@ public class ChangelogViewController {
 
     public ChangelogViewController() {
         this.gameVersionProperty = new SimpleObjectProperty<>();
-        gameVersionProperty.addListener((observableValue, oldVersion, newVersion) -> update(newVersion));
     }
 
     /**
@@ -50,111 +51,26 @@ public class ChangelogViewController {
     }
 
     /**
-     * Update the displayed changelog based on the selected `gameVersion`.
+     * Update the displayed changelog based on the selected package.
      *
-     * @param gameVersion
+     * @param changes list of changes
      */
-    private void update(TerasologyGameVersion gameVersion) {
-        final String gameInfoTextHTML;
-        if ((gameVersion == null) || (gameVersion.getJob() == null) || (gameVersion.getBuildNumber() == null)) {
-            gameInfoTextHTML = "";
-        } else {
-            gameInfoTextHTML = getGameInfoText(gameVersion);
-        }
-
-        changelogView.getEngine().loadContent(gameInfoTextHTML);
+    void update(final List<String> changes) {
+        changelogView.getEngine().loadContent(makeHtml(changes));
         changelogView.setBlendMode(BlendMode.LIGHTEN);
         changelogView.getEngine().setUserStyleSheetLocation(BundleUtils.getFXMLUrl("css_webview").toExternalForm());
     }
 
-    private String getGameInfoText(TerasologyGameVersion gameVersion) {
-//        logger.debug("Display game version: {} {}", gameVersion, gameVersion.getGameVersionInfo());
-//
-//        final Object[] arguments = new Object[9];
-//        arguments[0] = gameVersion.getJob().name();
-//        if (gameVersion.getJob().isStable()) {
-//            arguments[1] = 1;
-//        } else {
-//            arguments[1] = 0;
-//        }
-//        arguments[2] = gameVersion.getJob().getGitBranch();
-//        arguments[3] = gameVersion.getBuildNumber();
-//        if (gameVersion.isLatest()) {
-//            arguments[4] = 1;
-//        } else {
-//            arguments[4] = 0;
-//        }
-//        if (gameVersion.isInstalled()) {
-//            arguments[5] = 1;
-//        } else {
-//            arguments[5] = 0;
-//        }
-//        if (gameVersion.getSuccessful() != null) {
-//            if (!gameVersion.getSuccessful()) {
-//                // faulty
-//                arguments[6] = 0;
-//            } else {
-//                arguments[6] = 1;
-//            }
-//        } else {
-//            // unknown
-//            arguments[6] = 2;
-//        }
-//        if ((gameVersion.getGameVersionInfo() != null)
-//                && (gameVersion.getGameVersionInfo().getDisplayVersion() != null)) {
-//            arguments[7] = gameVersion.getGameVersionInfo().getDisplayVersion();
-//        } else {
-//            arguments[7] = "";
-//        }
-//        if ((gameVersion.getGameVersionInfo() != null)
-//                && (gameVersion.getGameVersionInfo().getDateTime() != null)) {
-//            arguments[8] = gameVersion.getGameVersionInfo().getDateTime();
-//        } else {
-//            arguments[8] = "";
-//        }
-//
-//        final String infoHeader1 = BundleUtils.getMessage(gameVersion.getJob().getInfoMessageKey(), arguments);
-//        final String infoHeader2 = BundleUtils.getMessage("infoHeader2", arguments);
-//
-//        final StringBuilder b = new StringBuilder();
-//        if ((infoHeader1 != null) && (infoHeader1.trim().length() > 0)) {
-//            b.append("<h1>")
-//                    .append(escapeHtml(infoHeader1))
-//                    .append("</h1>\n");
-//        }
-//        if ((infoHeader2 != null) && (infoHeader2.trim().length() > 0)) {
-//            b.append("<h2>")
-//                    .append(escapeHtml(infoHeader2))
-//                    .append("</h2>\n");
-//        }
-//        b.append("<strong>\n")
-//                .append(BundleUtils.getLabel("infoHeader3"))
-//                .append("</strong>\n");
-//
-//        if ((gameVersion.getChangeLog() != null) && !gameVersion.getChangeLog().isEmpty()) {
-//            b.append("<p>\n")
-//                    .append(BundleUtils.getLabel("infoHeader4"))
-//                    .append("<ul>\n");
-//            for (String msg : gameVersion.getChangeLog()) {
-//                b.append("<li>")
-//                        .append(escapeHtml(msg))
-//                        .append("</li>\n");
-//            }
-//            b.append("</ul>\n")
-//                    .append("</p>\n");
-//        }
-//
-//        /* Append changelogs of previous builds. */
-//        int previousLogs = gameVersion.getJob().isStable() ? 1 : 10;
-//        b.append("<hr/>");
-//        for (String msg : packageManager.getAggregatedChangeLog(gameVersion, previousLogs)) {
-//            b.append("<li>")
-//                    .append(escapeHtml(msg))
-//                    .append("</li>\n");
-//        }
-//
-//        return b.toString();
-        return "WIP";
+    private String makeHtml(final List<String> changes) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("<strong>")
+                .append(BundleUtils.getLabel("infoHeader4"))
+                .append("</strong>")
+                .append("<ul>");
+        changes.forEach(change -> builder.append("<li>").append(escapeHtml(change)).append("</li>"));
+        builder.append("</ul>");
+
+        return builder.toString();
     }
 
     private static String escapeHtml(String text) {

--- a/src/main/java/org/terasology/launcher/packages/Package.java
+++ b/src/main/java/org/terasology/launcher/packages/Package.java
@@ -17,6 +17,7 @@
 package org.terasology.launcher.packages;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * Model of a package handled by the PackageManager.
@@ -25,12 +26,14 @@ public class Package implements Serializable {
     private final String name;
     private final String version;
     private final String url;
+    private final List<String> changelog;
     private boolean installed;
 
-    Package(String name, String version, String url) {
+    Package(String name, String version, String url, List<String> changelog) {
         this.name = name;
         this.version = version;
         this.url = url;
+        this.changelog = changelog;
         installed = false;
     }
 
@@ -48,6 +51,10 @@ public class Package implements Serializable {
 
     public String getUrl() {
         return url;
+    }
+
+    public List<String> getChangelog() {
+        return changelog;
     }
 
     public boolean isInstalled() {


### PR DESCRIPTION
### Contains
Uses `JenkinsHandler` to download the changelog of packages during `PackageDatabase` synchronization, and stores it in the corresponding `Package` instance. This changelog is later written to the screen using `ChangelogViewController`.
Fixes #464. 

### How to test
1. Start the launcher normally
2. Select different packages from the combo-boxes
3. The corresponding changelog should be displayed immediately

### Outstanding before merging
- [x] Store changelog value in `Package`
- [x] Display changelog in main screen
- [x] Append changelog of upstream builds in Omega builds
