### PR TITLE
Initializes combo boxes and buttons as soon as FXML is loaded

### DIFF
--- a/src/main/java/org/terasology/launcher/TerasologyLauncher.java
+++ b/src/main/java/org/terasology/launcher/TerasologyLauncher.java
@@ -172,7 +172,7 @@ public final class TerasologyLauncher extends Application {
             root = (Parent) fxmlLoader.load();
         }
         final ApplicationController controller = fxmlLoader.getController();
-        controller.initialize(launcherConfiguration.getLauncherDirectory(), launcherConfiguration.getDownloadDirectory(), launcherConfiguration.getTempDirectory(),
+        controller.update(launcherConfiguration.getLauncherDirectory(), launcherConfiguration.getDownloadDirectory(), launcherConfiguration.getTempDirectory(),
             launcherConfiguration.getLauncherSettings(), launcherConfiguration.getPackageManager(), mainStage, hostServices);
 
         Scene scene = new Scene(root);

--- a/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
@@ -226,7 +226,8 @@ public class ApplicationController {
     @FXML
     public void initialize() {
         footerController.bind(warning);
-        buildVersionBox.setCellFactory(list -> new VersionListCell());
+        initComboBoxes();
+        initButtons();
     }
 
     @FXML
@@ -374,8 +375,8 @@ public class ApplicationController {
                 });
     }
 
-    public void initialize(final Path newLauncherDirectory, final Path newDownloadDirectory, final Path newTempDirectory, final BaseLauncherSettings newLauncherSettings,
-                           final PackageManager newPackageManager, final Stage newStage, final HostServices hostServices) {
+    public void update(final Path newLauncherDirectory, final Path newDownloadDirectory, final Path newTempDirectory, final BaseLauncherSettings newLauncherSettings,
+                       final PackageManager newPackageManager, final Stage newStage, final HostServices hostServices) {
         this.launcherDirectory = newLauncherDirectory;
         this.downloadDirectory = newDownloadDirectory;
         this.tempDirectory = newTempDirectory;
@@ -397,9 +398,6 @@ public class ApplicationController {
 
         packageItems = FXCollections.observableArrayList();
         onSync();
-
-        initComboBoxes();
-        initButtons();
 
         //TODO: This only updates when the launcher is initialized (which should happen excatly once o.O)
         //      We should update this value at least every time the download directory changes (user setting).
@@ -458,6 +456,9 @@ public class ApplicationController {
                          Collectors.mapping(VersionItem::new, Collectors.toList())))
                 .forEach((name, versions) ->
                         packageItems.add(new PackageItem(name, versions)));
+
+        jobBox.setItems(packageItems);
+        jobBox.getSelectionModel().select(0);
     }
 
     private void initComboBoxes() {
@@ -466,6 +467,7 @@ public class ApplicationController {
             buildVersionBox.getSelectionModel().select(0);
         });
 
+        buildVersionBox.setCellFactory(list -> new VersionListCell());
         buildVersionBox.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) -> {
             if (newVal == null) {
                 return;
@@ -483,9 +485,6 @@ public class ApplicationController {
 
             changelogViewController.update(selectedPackage.getChangelog());
         });
-
-        jobBox.setItems(packageItems);
-        jobBox.getSelectionModel().select(0);
     }
 
     private void initButtons() {


### PR DESCRIPTION
### Contains
Initializes the top buttons and `ChangeListener`s for the combo boxes as soon as `application.fxml` gets loaded. This makes the UI responsive before filling it with the package details.
Fixes #473.

### How to test
1. Start the launcher normally.
2. Observe the package selected by default. Do not select another!
3. If it's not installed, _Download_ button is shown and _Delete_ button is disabled. 
Otherwise, _Start_ button is shown and _Delete_ button is enabled.
4. Now install or remove the package and restart the launcher.
5. Check if the condition in step 3 is still satisfied.

For example, when _Terasology-2291_ is installed, it should look like:
![2019-12-05-102402_969x563_scrot](https://user-images.githubusercontent.com/14859252/70205436-065d0680-174a-11ea-8c63-2e260f14447f.png)

And when not installed, it should look like:
![2019-12-05-102511_969x563_scrot](https://user-images.githubusercontent.com/14859252/70205476-22f93e80-174a-11ea-88ae-8bf794f12bb6.png)