### PR TITLE
feature(jre): Automatically bundle JRE with distributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,5 @@ certum.jks
 web-api-client/
 
 # Ignore donwloaded JREs
+jre/**
 jres/**

--- a/build.gradle
+++ b/build.gradle
@@ -144,6 +144,7 @@ targetCompatibility = 1.8
 mainClassName = 'org.terasology.launcher.TerasologyLauncher'
 
 // Bundle JRE (Use gradle argument: -PbundleJre=/path/to/jre)
+//TODO should be controlled by tasks for different platforms, and not by argument
 if (project.hasProperty('bundleJre')) {
     applicationDistribution.from("$bundleJre") {
         into 'jre'
@@ -166,6 +167,52 @@ def convertGitBranch = { gitBranch ->
         gitBranch.substring(gitBranch.lastIndexOf("/") + 1)
     } else {
         ""
+    }
+}
+
+task createDocs {
+    def docs = file("$buildDir/docs")
+    outputs.dir docs
+    doLast {
+        docs.mkdirs()
+        new File(docs, 'readme.txt').write('Read me!')
+    }
+}
+
+//TODO change output path to avoid interference of different platforms
+/**
+ * Extract a previously downloaded JRE package into `$buildDir/jre`
+ */
+task unpackWin64Jre(type: Copy) {
+    from(zipTree(rootProject.file("./jre/windows-amd64.zip"))) {
+        include("jre*/**")
+        eachFile { fcd ->
+            fcd.relativePath = new RelativePath(true, fcd.relativePath.segments.drop(1))
+        }
+        includeEmptyDirs = false
+    }
+    into("$buildDir/jre")
+}
+
+//TODO generalize for other platforms
+/**
+ * Copy/extract a specific JRE into `$buildDir/jre` to be packaged later
+ */
+task prepareWin64Jre {
+    def jre = file("$buildDir/jre")
+    outputs.dir jre
+
+    dependsOn unpackWin64Jre
+}
+
+//TODO replace by dynamic packaging per platform
+distributions {
+    main {
+        contents {
+            from(prepareWin64Jre) {
+                into 'jre'
+            }
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -143,70 +143,12 @@ targetCompatibility = 1.8
 
 mainClassName = 'org.terasology.launcher.TerasologyLauncher'
 
-// Bundle JRE (Use gradle argument: -PbundleJre=/path/to/jre)
-//TODO should be controlled by tasks for different platforms, and not by argument
-if (project.hasProperty('bundleJre')) {
-    applicationDistribution.from("$bundleJre") {
-        into 'jre'
-    }
-
-    startScripts {
-        doLast {
-            unixScript.text = unixScript.text.replaceFirst(/(?s)# Determine the Java.*(?=\R# Increase)/,
-                    '# Use bundled JRE\nJAVACMD=\\$APP_HOME/jre/bin/java\n')
-
-            windowsScript.text = windowsScript.text.replaceFirst(/(?s)@rem Find java.*:init/,
-                    '@rem Use bundled JRE\nset JAVA_EXE=' + /%APP_HOME%\\jre\\bin\\java.exe/ + '\n')
-        }
-    }
-}
-
 def convertGitBranch = { gitBranch ->
     if (gitBranch != null) {
         // Remove "origin/" from "origin/develop"
         gitBranch.substring(gitBranch.lastIndexOf("/") + 1)
     } else {
         ""
-    }
-}
-
-//TODO change output path to avoid interference of different platforms
-/**
- * Extract a previously downloaded JRE package into `$buildDir/jre`
- */
-task unpackWin64Jre(type: Copy) {
-    from(zipTree(rootProject.file("./jre/windows-amd64.zip"))) {
-        include("jre*/**")
-        eachFile { fcd ->
-            fcd.relativePath = new RelativePath(true, fcd.relativePath.segments.drop(1))
-        }
-        includeEmptyDirs = false
-    }
-    into("$buildDir/jre")
-
-    dependsOn downloadJreWindows64
-}
-
-//TODO generalize for other platforms
-/**
- * Copy/extract a specific JRE into `$buildDir/jre` to be packaged later
- */
-task prepareWin64Jre {
-    def jre = file("$buildDir/jre")
-    outputs.dir jre
-
-    dependsOn unpackWin64Jre
-}
-
-//TODO replace by dynamic packaging per platform
-distributions {
-    win64 {
-        contents {
-            with distributions.main.contents
-            from(prepareWin64Jre) {
-                into 'jre'
-            }
-        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -170,15 +170,6 @@ def convertGitBranch = { gitBranch ->
     }
 }
 
-task createDocs {
-    def docs = file("$buildDir/docs")
-    outputs.dir docs
-    doLast {
-        docs.mkdirs()
-        new File(docs, 'readme.txt').write('Read me!')
-    }
-}
-
 //TODO change output path to avoid interference of different platforms
 /**
  * Extract a previously downloaded JRE package into `$buildDir/jre`
@@ -207,8 +198,9 @@ task prepareWin64Jre {
 
 //TODO replace by dynamic packaging per platform
 distributions {
-    main {
+    win64 {
         contents {
+            with distributions.main.contents
             from(prepareWin64Jre) {
                 into 'jre'
             }

--- a/build.gradle
+++ b/build.gradle
@@ -183,6 +183,8 @@ task unpackWin64Jre(type: Copy) {
         includeEmptyDirs = false
     }
     into("$buildDir/jre")
+
+    dependsOn downloadJreWindows64
 }
 
 //TODO generalize for other platforms

--- a/build.gradle
+++ b/build.gradle
@@ -117,10 +117,9 @@ dependencies {
     compile group: 'com.github.rjeschke', name: 'txtmark', version: '0.11'
 
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
+    compile group: "com.google.guava", name: "guava", version: "28.1-jre"
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.2'
     
-    implementation("com.google.guava:guava:28.1-jre")
-
     // For Web API
     // TODO: extract swagger dependencies into swagger.gradle
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.5'

--- a/config/gradle/jre.gradle
+++ b/config/gradle/jre.gradle
@@ -40,13 +40,17 @@ jreUrlFilenames.each { os, file ->
     def packedJre = new File("$projectDir/jre/$file")
     def unpackedJre = new File("$buildDir/jre/$os")
 
-    def downloadTask = task("downloadJre$os", type: Download) {
+    def downloadTask = task("downloadJre$os") {
         group 'Download'
         description "Downloads JRE for $os"
 
-        src "$jreUrlBase-$file"
-        dest packedJre
-        overwrite false
+        doFirst {
+            download {
+                src "$jreUrlBase-$file"
+                dest packedJre
+                overwrite false
+            }
+        }
 
         doLast {
             // Unpack the JRE

--- a/config/gradle/jre.gradle
+++ b/config/gradle/jre.gradle
@@ -1,46 +1,46 @@
-enum Jre {
-    // TODO Use `.tar.gz` on Linux
-    Linux32("zip"),
-    Linux64("zip"),
-    // TODO rename `Mac` to `MacOS` when artifact is renamed: https://github.com/MovingBlocks/TerasologyJRE/pull/5
-    Mac("zip"),
-    Windows32("zip"),
-    Windows64("zip");
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-    public URL downloadUrl;
-    public File targetArchive;
+// Uses Bellsoft Liberica JRE
+def jreVersion = '8u212'
+def jreUrlBase = "https://download.bell-sw.com/java/$jreVersion/bellsoft-jre$jreVersion"
+def jreUrlFilenames = [
+        Linux64   : 'linux-amd64.tar.gz',
+        Linux32   : 'linux-i586.tar.gz',
+        Windows64 : 'windows-amd64.zip',
+        Windows32 : 'windows-i586.zip',
+        Mac       : 'macos-amd64.zip'
+]
 
-    Jre(String extension) {
-        String baseUrl = "http://artifactory.terasology.org/artifactory/libs-release-local"
-
-        // TODO can we use gradle dependencies/configurations to download this for the bundling task?
-        // Use vendored JRE from our Artifactory
-        String groupId = "org/terasology/jre/liberica"
-        String artifactId = this.name().toLowerCase()
-        String version = "0.0.1"
-
-        String artifact = "${artifactId}-${version}.${extension}"
-
-        this.downloadUrl = new URL("${baseUrl}/${groupId}/${artifactId}/${version}/${artifact}")
-        this.targetArchive = new File("${artifact}")   
-    }
+task downloadJreAll {
+    group 'Download'
+    description 'Downloads JRE for all platforms'
 }
 
-task fetchJreAll {
-    group "Download"
-    description "Downloads JRE for all platforms"
-}
+jreUrlFilenames.each { os, file ->
+    def jreTask = "downloadJre$os"
 
-Jre.each { arch ->
-    def downloadTask = task("fetchJre${arch}", type: Download) {
-        group "Download"
-        description "Download JRE for ${arch}"
+    task "$jreTask"(type: Download) {
+        group 'Download'
+        description "Downloads JRE for $os"
 
-        src arch.downloadUrl
-        dest file("${project.projectDir}/jres/${arch.targetArchive}")
+        src "$jreUrlBase-$file"
+        dest "$projectDir/jre/$file"
         overwrite false
-        onlyIfModified true
     }
 
-    fetchJreAll.dependsOn downloadTask
+    downloadJreAll.dependsOn tasks.named(jreTask).get()
 }

--- a/config/gradle/jre.gradle
+++ b/config/gradle/jre.gradle
@@ -30,17 +30,97 @@ task downloadJreAll {
     description 'Downloads JRE for all platforms'
 }
 
-jreUrlFilenames.each { os, file ->
-    def jreTask = "downloadJre$os"
+task allDistZip {
+    group 'Distribution'
+    description 'Bundles the project with a JRE for each platform'
+    dependsOn distZip
+}
 
-    task "$jreTask"(type: Download) {
+jreUrlFilenames.each { os, file ->
+    def packedJre = new File("$projectDir/jre/$file")
+    def unpackedJre = new File("$buildDir/jre/$os")
+
+    def downloadTask = task("downloadJre$os", type: Download) {
         group 'Download'
         description "Downloads JRE for $os"
 
         src "$jreUrlBase-$file"
-        dest "$projectDir/jre/$file"
+        dest packedJre
         overwrite false
+
+        doLast {
+            // Unpack the JRE
+            if (!unpackedJre.exists()) {
+                unpackedJre.mkdirs()
+                copy {
+                    from(file.endsWith("zip")
+                            ? zipTree(packedJre)
+                            : tarTree(packedJre)) {
+                        eachFile { fcd ->
+                            fcd.relativePath = new RelativePath(
+                                    true, fcd.relativePath.segments.drop(1))
+                        }
+                        includeEmptyDirs = false
+                    }
+                    into unpackedJre
+                }
+            }
+        }
     }
 
-    downloadJreAll.dependsOn tasks.named(jreTask).get()
+    def distName = os.toLowerCase()
+    distributions {
+        "$distName" {
+            contents {
+                with distributions.main.contents
+                into('jre') {
+                    from unpackedJre
+                }
+            }
+        }
+    }
+
+    def zipTask = tasks.named("${distName}DistZip").get()
+    def tarTask = tasks.named("${distName}DistTar").get()
+
+    downloadJreAll.dependsOn downloadTask
+    zipTask.dependsOn downloadTask
+    zipTask.description "Bundles the project with a JRE for $os"
+    tarTask.dependsOn downloadTask
+    tarTask.description "Bundles the project with a JRE for $os"
+    allDistZip.dependsOn zipTask
+}
+
+/**
+ * Modify start scripts to use bundled JRE when
+ * available, otherwise fall back to searching.
+ */
+startScripts.doLast {
+    unixScript.text = unixScript
+            .text
+            .replaceFirst(/(?s)# Determine the Java.*(?=\R\R# Increase)/) { match ->
+                """\
+                |# Use bundled JRE when available
+                |if [ -d \$APP_HOME/jre ] ; then
+                |    JAVACMD=\$APP_HOME/jre/bin/java
+                |else
+                |    ${match.replace("\n", "\n    ")}
+                |fi"""
+                .stripMargin()
+            }
+
+    windowsScript.text = windowsScript
+            .text
+            .replaceFirst(/(?s)@rem Find java.*:init/) { match ->
+                """\
+                |@rem Use bundled JRE when available
+                |if not exist %APP_HOME%\\jre\\ goto findJava
+                |set JAVA_EXE=%APP_HOME%\\jre\\bin\\java.exe
+                |goto init
+                |
+                |:findJava
+                |$match
+                |"""
+                .stripMargin()
+            }
 }


### PR DESCRIPTION
This PR explores the usage of _tasks_ and _distributions_ (Gradle plug-in, included via the Applications plug-in) to bundle different packages per platform. 

Bundling the game via `distZip` as before should not change the output - there will be a single `TerasologyLauncher.zip` in the `build/distributions` folder **without** a bundled JRE.

```
./gradlew distZip
```

In addition, I've added a new _distribution_ called `win64` which shows how to bundle a previously downloaded JRE in a new distribution package called `TerasologyLauncher-win64.zip` (there is a task dependency which will download the JRE if it is not present).

```
./gradlew win64DistZip
```

The JRE is currently downloaded to `$projectRoot/jre/` which allows to cache it even after `gradlew clean`.

Part of #487

---

- [x] investigate how to use tasks and distributions for multi-platform packaging
- [x] generalize tasks / programmatically define tasks and distributions for each platform
- [x] test that all distributions work as expected
- [ ] clean up build scripts and other tasks which blindly copy files into the final distribution
