### PR TITLE
Running launcher without any JAVA installed.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 1.11
       uses: actions/setup-java@v1
       with:
         java-version: 1.11

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 1.11
         java-package: jdk+fx
     - name: Build with Gradle
       run: ./gradlew build

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,5 @@ certum.jks
 web-api-client/
 
 # Ignore donwloaded JREs
+jre/**
 jres/**

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ plugins {
     id 'project-report'
     id 'org.openjfx.javafxplugin' version '0.0.8'
     id 'org.beryx.jlink' version '2.17.0'
+    id 'org.javamodularity.moduleplugin' version '1.5.0'
 }
 
 apply from: "./config/gradle/jre.gradle"
@@ -57,7 +58,6 @@ apply from: "./config/gradle/environment.gradle"
 
 // Test for right version of Java in use for running this script
 assert JavaVersion.current().isJava11Compatible()
-def javaVersion = System.properties['java.version']
 
 // gradle wrapper version
 wrapper {
@@ -157,6 +157,17 @@ javafx {
 jlink {
     launcher {
         name = 'launcher'
+    }
+}
+
+// exclude module info files for Java 9
+checkstyleMain.exclude "**/module-info.java"
+checkstyleTest.exclude "**/module-info.java"
+
+test {
+    useJUnit()
+    moduleOptions {
+        runOnClasspath = true
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ test {
     }
 }
 
-mainClassName = 'terasology.launcher/org.terasology.launcher.TerasologyLauncher'
+mainClassName = 'org.terasology.launcher/org.terasology.launcher.TerasologyLauncher'
 
 // Bundle JRE (Use gradle argument: -PbundleJre=/path/to/jre)
 if (project.hasProperty('bundleJre')) {

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ plugins {
     id 'org.hidetake.swagger.generator' version '2.18.1'
     id 'pmd'
     id 'project-report'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 apply from: "./config/gradle/jre.gradle"
@@ -54,17 +55,15 @@ apply from: "./config/gradle/swagger.gradle"
 apply from: "./config/gradle/environment.gradle"
 
 // Test for right version of Java in use for running this script
-assert org.gradle.api.JavaVersion.current().isJava8Compatible()
+assert JavaVersion.current().isJava11Compatible()
 def javaVersion = System.properties['java.version']
 // make sure at least 8u40 is used for the build (required for JavaFX)
-if (javaVersion.startsWith("1.8") && javaVersion.split("_")[1].toInteger() < 40) {
-    throw new GradleException("Java version 1.8.0_40 or later required, but was $javaVersion")
-}
 
 // gradle wrapper version
 wrapper {
     gradleVersion '5.4.1'
 }
+
 
 import org.apache.tools.ant.filters.FixCrLfFilter
 
@@ -110,15 +109,15 @@ repositories {
 
 // Primary dependencies definition
 dependencies {
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.7'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '2.0.0-alpha1'
     compile group: 'net.java.dev.jna', name: 'jna', version: '4.1.0'
     compile group: 'net.java.dev.jna', name: 'jna-platform', version: '4.1.0'
     compile group: 'org.terasology', name: 'CrashReporter', version: '1.2.+'
     compile group: 'com.github.rjeschke', name: 'txtmark', version: '0.11'
 
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.2'
-    
+    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.0-alpha5'
+
     implementation("com.google.guava:guava:28.1-jre")
 
     // For Web API
@@ -130,16 +129,24 @@ dependencies {
 
     // These dependencies are only needed for running tests
     testCompile group: 'junit', name: 'junit', version: '4.11'
-    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.26.0'
+    testCompile group: 'org.mockito', name: 'mockito-inline', version: '2.26.0' // For final classes
 
-    // Don't upgrade either of these until https://github.com/powermock/powermock/issues/717 is resolved
-    testCompile 'org.powermock:powermock-module-junit4:1.6.4'
-    testCompile 'org.powermock:powermock-api-mockito:1.6.4'
+    testCompile 'org.powermock:powermock-module-junit4:2.0.4'
+    testCompile 'org.powermock:powermock-api-mockito2:2.0.2'
 }
 
 // Set the expected module Java level (can use a higher Java to run, but should not use features from a higher Java)
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.11
+targetCompatibility = 1.11
+
+javafx {
+    version = "11.0.2"
+    modules = [
+            'javafx.graphics',
+            'javafx.fxml',
+            'javafx.web']
+}
 
 mainClassName = 'org.terasology.launcher.TerasologyLauncher'
 
@@ -309,7 +316,7 @@ task createPatch(dependsOn: distZip) {
         File oldUnzipped = new File(patchDir, 'old/TerasologyLauncher/')
         File newUnzipped = new File(patchDir, 'new/TerasologyLauncher/')
 
-        String patchFileName = "$project.name-patch-$env.JOB_NAME-$lastSuccessfulBuildNumber-$env.BUILD_NUMBER"+".zip"
+        String patchFileName = "$project.name-patch-$env.JOB_NAME-$lastSuccessfulBuildNumber-$env.BUILD_NUMBER" + ".zip"
         File patchZip = new File(patchDir, patchFileName)
 
         logger.info("Creating patch file with: \n\told  : $oldUnzipped\n\tnew  : $newUnzipped\n\tpatch: $patchZip")

--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,9 @@ jlink {
     launcher {
         name = 'launcher'
     }
+
+    imageName = "TerasologyLauncher"
+
     ['Linux64',
     'Linux32',
     'Windows64',
@@ -165,13 +168,23 @@ jlink {
     'Mac'].each { name ->
         targetPlatform(name) {
             jdkHome = "jre/Launcher/$name/"
-
         }
     }
 }
 
-tasks.named("jlink").get().dependsOn "downloadJreLauncher" // For creating images for platforms.
-
+tasks.getByName("jlink").dependsOn "downloadJreAll" // For creating images for platforms.
+tasks.getByName("jlink").doLast {
+    ['Linux64',
+     'Linux32',
+     'Windows64',
+     'Windows32',
+     'Mac'].each { platform ->
+        copy {
+            from file("jre/Game/$platform")
+            into file("${buildDir}/${jlink.imageName.get()}/${jlink.launcherData.get().name}-${platform}/jre")
+        }
+    }
+}
 
 
 // exclude module info files for Java 9

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ plugins {
     id 'pmd'
     id 'project-report'
     id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.beryx.jlink' version '2.17.0'
 }
 
 apply from: "./config/gradle/jre.gradle"
@@ -57,7 +58,6 @@ apply from: "./config/gradle/environment.gradle"
 // Test for right version of Java in use for running this script
 assert JavaVersion.current().isJava11Compatible()
 def javaVersion = System.properties['java.version']
-// make sure at least 8u40 is used for the build (required for JavaFX)
 
 // gradle wrapper version
 wrapper {
@@ -116,9 +116,15 @@ dependencies {
     compile group: 'com.github.rjeschke', name: 'txtmark', version: '0.11'
 
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.0-alpha5'
+    compile (group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.0-alpha5') {
+        exclude module: "activation"
+    }
 
-    implementation("com.google.guava:guava:28.1-jre")
+    implementation("com.google.guava:guava:28.1-jre") {
+        // conflictiong in module-info.java...
+        exclude group: 'org.checkerframework', module: 'checker-qual'
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+    }
 
     // For Web API
     // TODO: extract swagger dependencies into swagger.gradle
@@ -146,6 +152,12 @@ javafx {
             'javafx.graphics',
             'javafx.fxml',
             'javafx.web']
+}
+
+jlink {
+    launcher {
+        name = 'launcher'
+    }
 }
 
 mainClassName = 'org.terasology.launcher.TerasologyLauncher'

--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     compile group: 'com.github.rjeschke', name: 'txtmark', version: '0.11'
 
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
-    compile (group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.0-alpha5') {
+    compile (group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.0-alpha4') {
         exclude module: "activation"
     }
 
@@ -160,7 +160,7 @@ jlink {
     }
 }
 
-mainClassName = 'org.terasology.launcher.TerasologyLauncher'
+mainClassName = 'terasology.launcher/org.terasology.launcher.TerasologyLauncher'
 
 // Bundle JRE (Use gradle argument: -PbundleJre=/path/to/jre)
 if (project.hasProperty('bundleJre')) {

--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,21 @@ jlink {
     launcher {
         name = 'launcher'
     }
+    ['Linux64',
+    'Linux32',
+    'Windows64',
+    'Windows32',
+    'Mac'].each { name ->
+        targetPlatform(name) {
+            jdkHome = "jre/Launcher/$name/"
+
+        }
+    }
 }
+
+tasks.named("jlink").get().dependsOn "downloadJreLauncher" // For creating images for platforms.
+
+
 
 // exclude module info files for Java 9
 checkstyleMain.exclude "**/module-info.java"

--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,7 @@ test {
 mainClassName = 'org.terasology.launcher/org.terasology.launcher.TerasologyLauncher'
 
 // Bundle JRE (Use gradle argument: -PbundleJre=/path/to/jre)
+//TODO should be controlled by tasks for different platforms, and not by argument
 if (project.hasProperty('bundleJre')) {
     applicationDistribution.from("$bundleJre") {
         into 'jre'
@@ -196,6 +197,52 @@ def convertGitBranch = { gitBranch ->
         gitBranch.substring(gitBranch.lastIndexOf("/") + 1)
     } else {
         ""
+    }
+}
+
+task createDocs {
+    def docs = file("$buildDir/docs")
+    outputs.dir docs
+    doLast {
+        docs.mkdirs()
+        new File(docs, 'readme.txt').write('Read me!')
+    }
+}
+
+//TODO change output path to avoid interference of different platforms
+/**
+ * Extract a previously downloaded JRE package into `$buildDir/jre`
+ */
+task unpackWin64Jre(type: Copy) {
+    from(zipTree(rootProject.file("./jre/windows-amd64.zip"))) {
+        include("jre*/**")
+        eachFile { fcd ->
+            fcd.relativePath = new RelativePath(true, fcd.relativePath.segments.drop(1))
+        }
+        includeEmptyDirs = false
+    }
+    into("$buildDir/jre")
+}
+
+//TODO generalize for other platforms
+/**
+ * Copy/extract a specific JRE into `$buildDir/jre` to be packaged later
+ */
+task prepareWin64Jre {
+    def jre = file("$buildDir/jre")
+    outputs.dir jre
+
+    dependsOn unpackWin64Jre
+}
+
+//TODO replace by dynamic packaging per platform
+distributions {
+    main {
+        contents {
+            from(prepareWin64Jre) {
+                into 'jre'
+            }
+        }
     }
 }
 

--- a/config/gradle/jre.gradle
+++ b/config/gradle/jre.gradle
@@ -1,46 +1,46 @@
-enum Jre {
-    // TODO Use `.tar.gz` on Linux
-    Linux32("zip"),
-    Linux64("zip"),
-    // TODO rename `Mac` to `MacOS` when artifact is renamed: https://github.com/MovingBlocks/TerasologyJRE/pull/5
-    Mac("zip"),
-    Windows32("zip"),
-    Windows64("zip");
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-    public URL downloadUrl;
-    public File targetArchive;
+// Uses Bellsoft Liberica JRE
+def jreVersion = '8u212'
+def jreUrlBase = "https://download.bell-sw.com/java/$jreVersion/bellsoft-jre$jreVersion"
+def jreUrlFilenames = [
+        Linux64   : 'linux-amd64.tar.gz',
+        Linux32   : 'linux-i586.tar.gz',
+        Windows64 : 'windows-amd64.zip',
+        Windows32 : 'windows-i586.zip',
+        Mac       : 'macos-amd64.zip'
+]
 
-    Jre(String extension) {
-        String baseUrl = "http://artifactory.terasology.org/artifactory/libs-release-local"
-
-        // TODO can we use gradle dependencies/configurations to download this for the bundling task?
-        // Use vendored JRE from our Artifactory
-        String groupId = "org/terasology/jre/liberica"
-        String artifactId = this.name().toLowerCase()
-        String version = "0.0.1"
-
-        String artifact = "${artifactId}-${version}.${extension}"
-
-        this.downloadUrl = new URL("${baseUrl}/${groupId}/${artifactId}/${version}/${artifact}")
-        this.targetArchive = new File("${artifact}")   
-    }
+task downloadJreAll {
+    group 'Download'
+    description 'Downloads JRE for all platforms'
 }
 
-task fetchJreAll {
-    group "Download"
-    description "Downloads JRE for all platforms"
-}
+jreUrlFilenames.each { os, file ->
+    def jreTask = "downloadJre$os"
 
-Jre.each { arch ->
-    def downloadTask = task("fetchJre${arch}", type: Download) {
-        group "Download"
-        description "Download JRE for ${arch}"
+    task "$jreTask"(type: Download) {
+        group 'Download'
+        description "Downloads JRE for $os"
 
-        src arch.downloadUrl
-        dest file("${project.projectDir}/jres/${arch.targetArchive}")
+        src "$jreUrlBase-$file"
+        dest "$projectDir/jre/$file"
         overwrite false
-        onlyIfModified true
     }
 
-    fetchJreAll.dependsOn downloadTask
+    downloadJreAll.dependsOn tasks.named(jreTask).get()
 }

--- a/config/gradle/jre.gradle
+++ b/config/gradle/jre.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,32 +15,78 @@
  */
 
 // Uses Bellsoft Liberica JRE
-def jreVersion = '8u212'
-def jreUrlBase = "https://download.bell-sw.com/java/$jreVersion/bellsoft-jre$jreVersion"
+def jreVersionGame = '8u212'
+def jdkVersionLauncher = '11.0.6+10' // jre version haven't jmod (needed for jlink/jpackager)
+
 def jreUrlFilenames = [
-        Linux64   : 'linux-amd64.tar.gz',
-        Linux32   : 'linux-i586.tar.gz',
-        Windows64 : 'windows-amd64.zip',
-        Windows32 : 'windows-i586.zip',
-        Mac       : 'macos-amd64.zip'
+        Linux64  : 'linux-amd64.tar.gz',
+        Linux32  : 'linux-i586.tar.gz',
+        Windows64: 'windows-amd64.zip',
+        Windows32: 'windows-i586.zip',
+        Mac      : 'macos-amd64.zip'
 ]
+
+task downloadJreGame {
+    group 'Download'
+    description 'Downloads Game JRE for all platforms'
+}
+
+task downloadJreLauncher {
+    group 'Download'
+    description 'Downloads Launcher JRE for all platforms'
+}
 
 task downloadJreAll {
     group 'Download'
     description 'Downloads JRE for all platforms'
+    dependsOn downloadJreGame, downloadJreLauncher
 }
 
-jreUrlFilenames.each { os, file ->
-    def jreTask = "downloadJre$os"
+def createJreTasks(String taskNameBase,
+                   String downloadUrl,
+                   String downloadFile,
+                   String unpackDir) {
 
-    task "$jreTask"(type: Download) {
+    task "download$taskNameBase"(type: Download) {
         group 'Download'
-        description "Downloads JRE for $os"
-
-        src "$jreUrlBase-$file"
-        dest "$projectDir/jre/$file"
+        src downloadUrl
+        dest downloadFile
         overwrite false
     }
 
-    downloadJreAll.dependsOn tasks.named(jreTask).get()
+    task "unpack$taskNameBase"(type: Copy) {
+        def archive
+        if (downloadFile.endsWith('tar.gz')) {
+            archive = tarTree(resources.gzip(downloadFile))
+        } else {
+            archive = zipTree(downloadFile)
+        }
+        from(archive){
+            include "*/**"
+            eachFile { fcd ->
+                fcd.relativePath = new RelativePath(true, fcd.relativePath.segments.drop(1))
+            }
+            includeEmptyDirs = false
+        }
+        into unpackDir
+        dependsOn tasks.named("download$taskNameBase")
+    }
+
+    return tasks.named("unpack$taskNameBase").get()
+}
+
+jreUrlFilenames.each { os, file ->
+    // JRE 8
+    downloadJreGame.dependsOn createJreTasks(
+            "Jre${os}Game",
+            "https://download.bell-sw.com/java/$jreVersionGame/bellsoft-jre$jreVersionGame-$file",
+            "$projectDir/jre/$os-$jreVersionGame-$file",
+            "$projectDir/jre/Game/$os")
+
+    // JDK 11
+    downloadJreLauncher.dependsOn createJreTasks(
+            "Jre${os}Launcher",
+            "https://download.bell-sw.com/java/$jdkVersionLauncher/bellsoft-jdk$jdkVersionLauncher-$file",
+            "$projectDir/jre/$os-$jdkVersionLauncher-$file",
+            "$projectDir/jre/Launcher/$os")
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-module terasology.launcher {
+module org.terasology.launcher {
     //Logging
     requires org.slf4j;
     requires ch.qos.logback.classic;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -21,5 +21,6 @@ module terasology.launcher {
     requires java.desktop;
 
     exports org.terasology.launcher; // for launcher run
+    exports org.terasology.launcher.log to ch.qos.logback.core; // for TempLogFilePropertyDefiner
     opens org.terasology.launcher.gui.javafx to javafx.fxml; // for fxml controller access
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,20 @@
+module terasology.launcher {
+    //Logging
+    requires org.slf4j;
+    requires ch.qos.logback.classic;
+    requires java.naming;
+
+    requires txtmark;
+    requires com.google.common;
+    requires javafx.fxml;
+    requires javafx.controls;
+    requires javafx.web;
+    requires CrashReporter;
+    requires gson;
+    requires ch.qos.logback.core;
+    requires java.desktop;
+    requires jna;
+    requires jna.platform;
+
+    exports org.terasology.launcher;
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -2,19 +2,24 @@ module terasology.launcher {
     //Logging
     requires org.slf4j;
     requires ch.qos.logback.classic;
+    requires ch.qos.logback.core;
     requires java.naming;
 
+    // Automatic modules
+    requires CrashReporter;
     requires txtmark;
     requires com.google.common;
-    requires javafx.fxml;
-    requires javafx.controls;
-    requires javafx.web;
-    requires CrashReporter;
     requires gson;
-    requires ch.qos.logback.core;
-    requires java.desktop;
+    requires java.sql; // gson requires it :(
     requires jna;
     requires jna.platform;
 
-    exports org.terasology.launcher;
+    // openJavaFX and AWT
+    requires javafx.fxml;
+    requires javafx.controls;
+    requires javafx.web;
+    requires java.desktop;
+
+    exports org.terasology.launcher; // for launcher run
+    opens org.terasology.launcher.gui.javafx to javafx.fxml; // for fxml controller access
 }

--- a/src/main/java/org/terasology/launcher/TerasologyLauncher.java
+++ b/src/main/java/org/terasology/launcher/TerasologyLauncher.java
@@ -132,7 +132,16 @@ public final class TerasologyLauncher extends Application {
             }
         });
 
-        launcherInitTask.setOnFailed(event -> {openCrashReporterAndExit(new RuntimeException("FUUU"));});
+        launcherInitTask.setOnFailed(event -> {
+            Throwable throwable = event.getSource().getException();
+            Exception exception;
+            if (throwable instanceof Exception) {
+                exception = (Exception) throwable;
+            } else {
+                exception = new Exception("Wrapped throwable, see deeper", throwable);
+            }
+            openCrashReporterAndExit(exception);
+        });
 
         initThread.start();
     }
@@ -176,7 +185,7 @@ public final class TerasologyLauncher extends Application {
         }
         final ApplicationController controller = fxmlLoader.getController();
         controller.update(launcherConfiguration.getLauncherDirectory(), launcherConfiguration.getDownloadDirectory(), launcherConfiguration.getTempDirectory(),
-            launcherConfiguration.getLauncherSettings(), launcherConfiguration.getPackageManager(), mainStage, hostServices);
+                launcherConfiguration.getLauncherSettings(), launcherConfiguration.getPackageManager(), mainStage, hostServices);
 
         Scene scene = new Scene(root);
         scene.getStylesheets().add(BundleUtils.getStylesheet("css_terasology"));

--- a/src/main/java/org/terasology/launcher/TerasologyLauncher.java
+++ b/src/main/java/org/terasology/launcher/TerasologyLauncher.java
@@ -111,6 +111,7 @@ public final class TerasologyLauncher extends Application {
 
         showSplashStage(initialStage, launcherInitTask);
         Thread initThread = new Thread(launcherInitTask);
+        initThread.setName("Launcher init thread");
 
         launcherInitTask.setOnSucceeded(new EventHandler<WorkerStateEvent>() {
             @Override
@@ -130,6 +131,8 @@ public final class TerasologyLauncher extends Application {
                 }
             }
         });
+
+        launcherInitTask.setOnFailed(event -> {openCrashReporterAndExit(new RuntimeException("FUUU"));});
 
         initThread.start();
     }

--- a/src/main/java/org/terasology/launcher/game/GameStarter.java
+++ b/src/main/java/org/terasology/launcher/game/GameStarter.java
@@ -22,10 +22,12 @@ import org.terasology.launcher.packages.Package;
 import org.terasology.launcher.util.JavaHeapSize;
 import org.terasology.launcher.util.LogLevel;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public final class GameStarter {
 
@@ -80,7 +82,7 @@ public final class GameStarter {
     private List<String> createProcessParameters(Path gamePath, Path gameDataDirectory, List<String> javaParameters,
                                                  List<String> gameParameters) {
         final List<String> processParameters = new ArrayList<>();
-        processParameters.add(System.getProperty("java.home") + "/bin/java"); // Use the current java
+        processParameters.add(System.getProperty("java.home") + "/jre/bin/java"); // Use the bundled java
         processParameters.addAll(javaParameters);
         processParameters.add("-jar");
         processParameters.add(gamePath.resolve("libs/Terasology.jar").toString());

--- a/src/main/java/org/terasology/launcher/gui/javafx/ChangelogViewController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/ChangelogViewController.java
@@ -58,7 +58,11 @@ public class ChangelogViewController {
     void update(final List<String> changes) {
         changelogView.getEngine().loadContent(makeHtml(changes));
         changelogView.setBlendMode(BlendMode.LIGHTEN);
-        changelogView.getEngine().setUserStyleSheetLocation(BundleUtils.getFXMLUrl("css_webview").toExternalForm());
+        // TODO: return "changelogView.getEngine().setUserStyleSheetLocation(BundleUtils.getFxmlUrl(css_webview).toExternalForm())",
+        //  when https://github.com/openjdk/jfx/pull/22 has been merged.
+        //  See changelog-view.fxml
+        changelogView.getEngine().setUserStyleSheetLocation(
+                BundleUtils.getBundleResourceContentAsDataUrl("css_webview", "text/css"));
     }
 
     private String makeHtml(final List<String> changes) {

--- a/src/main/java/org/terasology/launcher/log/TempLogFilePropertyDefiner.java
+++ b/src/main/java/org/terasology/launcher/log/TempLogFilePropertyDefiner.java
@@ -48,6 +48,9 @@ public class TempLogFilePropertyDefiner extends PropertyDefinerBase {
     }
 
     public static TempLogFilePropertyDefiner getInstance() {
+        if (instance == null) { // TODO: fast fix, rethink it
+            instance = new TempLogFilePropertyDefiner();
+        }
         return instance;
     }
 
@@ -68,6 +71,7 @@ public class TempLogFilePropertyDefiner extends PropertyDefinerBase {
 
     /**
      * Set the prefix string for generating the file's name.
+     *
      * @param prefix the prefix string to be used in generating the file's name; may be null
      */
     public void setPrefix(String prefix) {
@@ -80,6 +84,7 @@ public class TempLogFilePropertyDefiner extends PropertyDefinerBase {
 
     /**
      * Set the suffix string for generating the file's name.
+     *
      * @param suffix the suffix string to be used in generating the file's name; may be null, in which case ".tmp" is used
      */
     public void setSuffix(String suffix) {
@@ -88,6 +93,7 @@ public class TempLogFilePropertyDefiner extends PropertyDefinerBase {
 
     /**
      * Returns the temporary log file.
+     *
      * @return the log file
      */
     public Path getLogFile() {

--- a/src/main/java/org/terasology/launcher/util/BundleUtils.java
+++ b/src/main/java/org/terasology/launcher/util/BundleUtils.java
@@ -115,6 +115,13 @@ public final class BundleUtils {
         return BundleUtils.class.getResource(url + '/' + relative);
     }
 
+    /**
+     * Get stylesheet url for bind it in javafx stylesheets
+     *
+     * @param key the key as specified in the fxml bundle file
+     * @return url, which locating requested stylesheet.
+     *              Received url use protocol jrt:// (java 9+)
+     */
     public static String getStylesheet(String key) {
         String moduleName = BundleUtils.class.getModule().getName();
         String resourcePath = ResourceBundle.getBundle(FXML_BUNDLE, Languages.getCurrentLocale()).getString(key);
@@ -126,6 +133,15 @@ public final class BundleUtils {
         return String.format("jrt:/%s/%s", moduleName, resourcePath);
     }
 
+    /**
+     * Get bundle's resource as data url.
+     * Using for webviews (webview in javafx cannot handle resource with protocol jrt)
+     * {@see https://github.com/openjdk/jfx/pull/22}
+     *
+     * @param key the key as specified in the fxml bundle file
+     * @param mimeType the mimetype of resource
+     * @return url in data form (data:{mimetype};base64;{data as base64})
+     */
     public static String getBundleResourceContentAsDataUrl(String key, String mimeType) {
         try (InputStream stream = BundleUtils.getFXMLUrl(key).openStream();
              BufferedInputStream bufferedInputStream = new BufferedInputStream(stream)) {

--- a/src/main/java/org/terasology/launcher/util/BundleUtils.java
+++ b/src/main/java/org/terasology/launcher/util/BundleUtils.java
@@ -111,6 +111,13 @@ public final class BundleUtils {
     }
 
     public static String getStylesheet(String key) {
-        return ResourceBundle.getBundle(FXML_BUNDLE, Languages.getCurrentLocale()).getString(key);
+        String moduleName = BundleUtils.class.getModule().getName();
+        String resourcePath = ResourceBundle.getBundle(FXML_BUNDLE, Languages.getCurrentLocale()).getString(key);
+        if (resourcePath.startsWith("/")) {
+            resourcePath = resourcePath.substring(1);
+        }
+        // Make JIGSAW's specific path for resource with module path.
+        // jrt - new protocol for access resources in JIGSAW's modules
+        return String.format("jrt:/%s/%s", moduleName, resourcePath);
     }
 }

--- a/src/main/java/org/terasology/launcher/util/BundleUtils.java
+++ b/src/main/java/org/terasology/launcher/util/BundleUtils.java
@@ -21,10 +21,15 @@ import javafx.scene.image.Image;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
+import java.util.Base64;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
@@ -119,5 +124,18 @@ public final class BundleUtils {
         // Make JIGSAW's specific path for resource with module path.
         // jrt - new protocol for access resources in JIGSAW's modules
         return String.format("jrt:/%s/%s", moduleName, resourcePath);
+    }
+
+    public static String getBundleResourceContentAsDataUrl(String key, String mimeType) {
+        try (InputStream stream = BundleUtils.getFXMLUrl(key).openStream();
+             BufferedInputStream bufferedInputStream = new BufferedInputStream(stream)) {
+
+            byte[] cssContent = bufferedInputStream.readAllBytes();
+            byte[] base64Content = Base64.getUrlEncoder().encode(cssContent);
+            return String.format("data:%s;base64,%s", mimeType, new String(base64Content, StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            logger.error("Cannot load css for WebView", e);
+        }
+        return null;
     }
 }

--- a/src/test/java/org/terasology/launcher/TestingUtils.java
+++ b/src/test/java/org/terasology/launcher/TestingUtils.java
@@ -24,9 +24,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.anyString;
 
 public final class TestingUtils {
 
@@ -62,11 +62,11 @@ public final class TestingUtils {
             latestBuilds.put(entry.getKey(), Collections.max(entry.getValue().keySet()));
         }
 
-        PowerMockito.doAnswer((i) -> latestBuilds.get(i.getArgumentAt(0, String.class))).
+        PowerMockito.doAnswer((i) -> latestBuilds.get(i.getArgument(0, String.class))).
                 when(DownloadUtils.class, "loadBuildNumberJenkins", anyString(), anyString());
 
         PowerMockito.doAnswer((i) ->
-                buildValues.hasEntry(i.getArgumentAt(0, String.class), i.getArgumentAt(1, Integer.class)) ? JobResult.SUCCESS : JobResult.NOT_BUILT)
+                buildValues.hasEntry(i.getArgument(0, String.class), i.getArgument(1, Integer.class)) ? JobResult.SUCCESS : JobResult.NOT_BUILT)
                 .when(DownloadUtils.class, "loadJobResultJenkins", anyString(), anyInt());
 
         PowerMockito.doReturn(null).when(DownloadUtils.class, "loadChangeLogJenkins", anyString(), anyInt());
@@ -74,8 +74,8 @@ public final class TestingUtils {
         // Omega trigger
         // This lambda simulates the behavior of an actual Jenkins server, mapping an omega build number to a 'linked' normal build
         PowerMockito.doAnswer((i) -> {
-            GameJob job = i.getArgumentAt(0, GameJob.class);
-            int omegaBuildNumber = i.getArgumentAt(1, int.class);
+            GameJob job = i.getArgument(0, GameJob.class);
+            int omegaBuildNumber = i.getArgument(1, Integer.class);
             return buildValues.getNormalFromOmega(job.name(), omegaBuildNumber);
         }).when(DownloadUtils.class, "loadEngineTriggerJenkins", anyObject(), anyInt());
     }

--- a/src/test/java/org/terasology/launcher/game/TestGameRunner.java
+++ b/src/test/java/org/terasology/launcher/game/TestGameRunner.java
@@ -18,9 +18,9 @@ package org.terasology.launcher.game;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.eq;
@@ -82,13 +82,13 @@ public class TestGameRunner {
         gameRunner.run();
 
         // Make sure GameRunner logs TEST_STRING line 1
-        verify((Logger) Whitebox.getInternalState(gameRunner, "logger")).trace(
+        verify((Logger) Whitebox.getInternalState(GameRunner.class, "logger")).trace(
                 "Game output: {}",
                 testString.substring(0, testString.indexOf("\n"))
         );
 
         // Make sure GameRunner logs TEST_STRING line 2
-        verify((Logger) Whitebox.getInternalState(gameRunner, "logger")).trace(
+        verify((Logger) Whitebox.getInternalState(GameRunner.class, "logger")).trace(
                 "Game output: {}",
                 testString.substring(testString.indexOf("\n") + 1)
         );
@@ -103,7 +103,7 @@ public class TestGameRunner {
         gameRunner.run();
 
         // Make sure GameRunner logs that the game exited
-        verify((Logger) Whitebox.getInternalState(gameRunner, "logger"), atLeastOnce()).debug(
+        verify((Logger) Whitebox.getInternalState(GameRunner.class, "logger"), atLeastOnce()).debug(
                 "Game closed with the exit value '{}'.",
                 0
         );
@@ -126,7 +126,7 @@ public class TestGameRunner {
         gameRunner.run();
 
         // Make sure GameRunner logs that the game thread was interrupted
-        verify((Logger) Whitebox.getInternalState(gameRunner, "logger")).debug("Game thread interrupted.");
+        verify((Logger) Whitebox.getInternalState(GameRunner.class, "logger")).debug("Game thread interrupted.");
     }
 
     @Test
@@ -141,7 +141,7 @@ public class TestGameRunner {
         gameRunner.run();
 
         // Make sure GameRunner logs an error with an InterruptedException
-        verify((Logger) Whitebox.getInternalState(gameRunner, "logger")).error(eq("The game thread was interrupted!"), any(InterruptedException.class));
+        verify((Logger) Whitebox.getInternalState(GameRunner.class, "logger")).error(eq("The game thread was interrupted!"), any(InterruptedException.class));
     }
 
     @Test
@@ -159,6 +159,6 @@ public class TestGameRunner {
         gameRunner.run();
 
         // Make sure GameRunner logs an error with an IOException
-        verify((Logger) Whitebox.getInternalState(gameRunner, "logger")).error(eq("Could not read game output!"), any(IOException.class));
+        verify((Logger) Whitebox.getInternalState(GameRunner.class, "logger")).error(eq("Could not read game output!"), any(IOException.class));
     }
 }

--- a/src/test/java/org/terasology/launcher/game/TestGameVersions.java
+++ b/src/test/java/org/terasology/launcher/game/TestGameVersions.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.terasology.launcher.TestingUtils;
@@ -34,11 +35,12 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.IntStream;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.powermock.api.mockito.PowerMockito.spy;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({DownloadUtils.class, TerasologyGameVersions.class})
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
 public class TestGameVersions {
 
     // These functions are common assertions, to be used with requireAssertions
@@ -200,7 +202,7 @@ public class TestGameVersions {
         // We suppress fetching the game version info, so that the test doesn't depend on the network
         // and is deterministic
         PowerMockito.doAnswer((i) -> {
-            TerasologyGameVersion version = i.getArgumentAt(0, TerasologyGameVersion.class);
+            TerasologyGameVersion version = i.getArgument(0, TerasologyGameVersion.class);
             version.setGameVersionInfo(TerasologyGameVersionInfo.getEmptyGameVersionInfo());
             return null;
         }).when(gameVersions, "loadAndSetGameVersionInfo", any(), any(), any(), any());

--- a/src/test/java/org/terasology/launcher/updater/TestLancherUpdater.java
+++ b/src/test/java/org/terasology/launcher/updater/TestLancherUpdater.java
@@ -19,6 +19,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.terasology.launcher.TestingUtils;
@@ -34,6 +35,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({DownloadUtils.class, LauncherUpdater.class})
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
 public final class TestLancherUpdater {
 
     private static String buildNumber;

--- a/src/test/java/org/terasology/launcher/util/TestFileUtils.java
+++ b/src/test/java/org/terasology/launcher/util/TestFileUtils.java
@@ -31,8 +31,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -161,38 +159,6 @@ public class TestFileUtils {
 
         assertTrue(Files.exists(fileInDestination));
         assertArrayEquals(Files.readAllBytes(fileInSource), Files.readAllBytes(fileInDestination));
-    }
-
-    @Test
-    public void testExtract() throws IOException {
-        final String fileInRoot = "fileInRoot";
-        final String fileInFolder = "folder/fileInFolder";
-        final String file1Contents = SAMPLE_TEXT + "1";
-        final String file2Contents = SAMPLE_TEXT + "2";
-        /* An archive with this structure is created:
-         * <zip root>
-         * +-- fileInRoot
-         * +-- folder
-         * |   +-- fileInFolder
-         */
-        Path zipFile = tempFolder.newFile(FILE_NAME + ".zip").toPath();
-        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(zipFile))) {
-            zipOutputStream.putNextEntry(new ZipEntry(fileInRoot));
-            zipOutputStream.write(file1Contents.getBytes());
-            zipOutputStream.closeEntry();
-            zipOutputStream.putNextEntry(new ZipEntry(fileInFolder));
-            zipOutputStream.write(file2Contents.getBytes());
-            zipOutputStream.closeEntry();
-        }
-
-        Path outputDir = tempFolder.newFolder().toPath();
-        FileUtils.extractZipTo(zipFile, outputDir);
-        Path extractedFileInRoot = outputDir.resolve(fileInRoot);
-        Path extractedFileInFolder = outputDir.resolve(fileInFolder);
-        assertTrue(Files.exists(extractedFileInRoot));
-        assertTrue(Files.exists(extractedFileInFolder));
-        assertEquals(file1Contents, Files.readAllLines(extractedFileInRoot).get(0));
-        assertEquals(file2Contents, Files.readAllLines(extractedFileInFolder).get(0));
     }
 
     @Test

--- a/src/test/java/org/terasology/launcher/util/TestFileUtils.java
+++ b/src/test/java/org/terasology/launcher/util/TestFileUtils.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -42,6 +43,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(FileUtils.class)
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
 public class TestFileUtils {
 
     private static final String FILE_NAME = "File";

--- a/src/test/java/org/terasology/launcher/util/TestFileUtilsNoMock.java
+++ b/src/test/java/org/terasology/launcher/util/TestFileUtilsNoMock.java
@@ -1,0 +1,58 @@
+package org.terasology.launcher.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Power mock trying make public all methods from jdk.nio.zipfs. that restricted and not needed (deleteFile)
+ */
+public class TestFileUtilsNoMock {
+
+    private static final String FILE_NAME = "File";
+    private static final String SAMPLE_TEXT = "Lorem Ipsum";
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void testExtract() throws IOException {
+        final String fileInRoot = "fileInRoot";
+        final String fileInFolder = "folder/fileInFolder";
+        final String file1Contents = SAMPLE_TEXT + "1";
+        final String file2Contents = SAMPLE_TEXT + "2";
+        /* An archive with this structure is created:
+         * <zip root>
+         * +-- fileInRoot
+         * +-- folder
+         * |   +-- fileInFolder
+         */
+        Path zipFile = tempFolder.newFile(FILE_NAME + ".zip").toPath();
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(zipFile))) {
+            zipOutputStream.putNextEntry(new ZipEntry(fileInRoot));
+            zipOutputStream.write(file1Contents.getBytes());
+            zipOutputStream.closeEntry();
+            zipOutputStream.putNextEntry(new ZipEntry(fileInFolder));
+            zipOutputStream.write(file2Contents.getBytes());
+            zipOutputStream.closeEntry();
+        }
+
+        Path outputDir = tempFolder.newFolder().toPath();
+        FileUtils.extractZipTo(zipFile, outputDir);
+        Path extractedFileInRoot = outputDir.resolve(fileInRoot);
+        Path extractedFileInFolder = outputDir.resolve(fileInFolder);
+        assertTrue(Files.exists(extractedFileInRoot));
+        assertTrue(Files.exists(extractedFileInFolder));
+        assertEquals(file1Contents, Files.readAllLines(extractedFileInRoot).get(0));
+        assertEquals(file2Contents, Files.readAllLines(extractedFileInFolder).get(0));
+    }
+}

--- a/src/test/java/org/terasology/launcher/util/TestLauncherDirectoryUtils.java
+++ b/src/test/java/org/terasology/launcher/util/TestLauncherDirectoryUtils.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -35,6 +36,7 @@ import static org.terasology.launcher.util.LauncherDirectoryUtils.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(LauncherDirectoryUtils.class)
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
 public class TestLauncherDirectoryUtils {
 
     @Rule

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
### Contains

* Upgrading to java 11
* Migration to OpenJavaFX 11
* Migration to Jigsaw modules (required for runtime-image creation)
* Integrate jlink's runtime-image (can run launcher without Java on Machine)

[warn] You need java 11+ for build
### How to test

1. ```gradlew run``` - it's work, launcher starts and works... also pretty look
2. ```gradlew jlink``` - Task finished fine, you can start launcher at ```<projectDir>/build/image/bin/launcher```

3. now, delete any java in system (or somehow disable java from current terminal/console/etc)
4. run launcher via ```<projectDir>/build/image/bin/launcher``` - it's work!

instead (4) you can download builded images from here: https://github.com/DarkWeird/TerasologyLauncher/actions?query=workflow%3A%22JavaFX+%2B+jlink%22
and run on machine without java installed

### Outstanding before merging

- [x] Upgrade to Java 11
- [x] Upgrade to OpenJavaFX11
- [x] Modularize project
- [x] Make runtime-image generation
- [x] Integrate Jre bundle for running game
- [x] Fix problems with CSS in java modules and runtime-image (```#441``` at github.com/javafxports/openjdk-jfx )
- [x] Repair tests after integrate Jigsaw
 