### PR TITLE
refactor(config): Dependency Inversion on `ConfigManager` and `ConfigReader`

### DIFF
--- a/src/main/java/org/terasology/launcher/config/ConfigValidator.java
+++ b/src/main/java/org/terasology/launcher/config/ConfigValidator.java
@@ -28,10 +28,10 @@ import org.terasology.launcher.util.JavaHeapSize;
 class ConfigValidator {
     private static final Logger logger = LoggerFactory.getLogger(ConfigValidator.class);
 
-    private final Config defaultConfig;
+    private final Config fallbackConfiguration;
 
     ConfigValidator(final Config defaultConfig) {
-        this.defaultConfig = defaultConfig;
+        this.fallbackConfiguration = defaultConfig;
     }
 
     /**
@@ -67,7 +67,7 @@ class ConfigValidator {
         ) {
             valid = gameConfig.getMaxMemory();
         } else {
-            valid = defaultConfig.getGameConfig().getMaxMemory();
+            valid = fallbackConfiguration.getGameConfig().getMaxMemory();
             logger.warn("Max memory cannot be greater than 1.5 GB for a 32-bit JVM");
             logger.debug("Continuing with max memory: {}", valid);
         }

--- a/src/main/java/org/terasology/launcher/config/ConfigWriter.java
+++ b/src/main/java/org/terasology/launcher/config/ConfigWriter.java
@@ -16,6 +16,7 @@
 
 package org.terasology.launcher.config;
 
+import com.google.gson.Gson;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
 import org.slf4j.Logger;
@@ -34,12 +35,22 @@ import java.nio.file.Path;
 class ConfigWriter extends Service<Void> {
     private static final Logger logger = LoggerFactory.getLogger(ConfigWriter.class);
 
-    private final ConfigManager manager;
     private final Path configPath;
+    private final Gson encoder;
 
-    ConfigWriter(ConfigManager manager) {
-        this.manager = manager;
-        configPath = manager.getConfigPath();
+    private Config config;
+
+    ConfigWriter(final Path configPath, final Gson encoder, final Config config) {
+        this.configPath = configPath;
+        this.encoder = encoder;
+        this.config = config;
+    }
+
+    public void setConfig(final Config config) {
+        if (config == null) {
+            throw new IllegalArgumentException("Configuration instance 'config' must not be 'null'!");
+        }
+        this.config = config;
     }
 
     @Override
@@ -50,7 +61,7 @@ class ConfigWriter extends Service<Void> {
                 try (BufferedWriter writer = new BufferedWriter(
                         new OutputStreamWriter(Files.newOutputStream(configPath))
                 )) {
-                    manager.getGson().toJson(manager.getConfig(), Config.class, writer);
+                    encoder.toJson(config, Config.class, writer);
                 }
                 return null;
             }


### PR DESCRIPTION
This is a follow-up to #481.

Along with some smaller follow-up changes this inverts the dependencies to break circles in the dependency graph.

Looking at the dependency graph of the `config` package I noticed a few downwards arrows. You can see them in this diagram generated by IDEA:
![terasology-launcher_package-config_develop](https://user-images.githubusercontent.com/1448874/74269224-73bc8300-4d09-11ea-8492-388aa2afc0cc.png)

I'm trying to untangle them in this PR such that all arrows point upwards:
![terasology-launcher_package-config_refactored](https://user-images.githubusercontent.com/1448874/74269496-dc0b6480-4d09-11ea-86bc-c63a9b636220.png)
