### PR TITLE
Upgrade to java 11

### DIFF
--- a/.github/workflows/push-validation.yml
+++ b/.github/workflows/push-validation.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 1.11
         java-package: jdk+fx
     - name: Build and test with Gradle
       run: ./gradlew test

--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,8 @@ task createVersionInfoFile {
 
     outputs.file(versionInfoFile)
 
+    onlyIf {env.JOB_NAME != null }
+
     doLast {
         versionInfoFileDir.mkdirs()
         ant.propertyfile(file: versionInfoFile) {

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ plugins {
     id 'org.hidetake.swagger.generator' version '2.18.1'
     id 'pmd'
     id 'project-report'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 apply from: "./config/gradle/jre.gradle"
@@ -55,17 +56,13 @@ apply from: "./config/gradle/swagger.gradle"
 apply from: "./config/gradle/environment.gradle"
 
 // Test for right version of Java in use for running this script
-assert org.gradle.api.JavaVersion.current().isJava8Compatible()
-def javaVersion = System.properties['java.version']
-// make sure at least 8u40 is used for the build (required for JavaFX)
-if (javaVersion.startsWith("1.8") && javaVersion.split("_")[1].toInteger() < 40) {
-    throw new GradleException("Java version 1.8.0_40 or later required, but was $javaVersion")
-}
+assert JavaVersion.current().isJava11Compatible()
 
 // gradle wrapper version
 wrapper {
     gradleVersion '5.4.1'
 }
+
 
 import org.apache.tools.ant.filters.FixCrLfFilter
 
@@ -98,16 +95,18 @@ repositories {
 
 // Primary dependencies definition
 dependencies {
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.7'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '2.0.0-alpha1'
     compile group: 'net.java.dev.jna', name: 'jna', version: '4.1.0'
     compile group: 'net.java.dev.jna', name: 'jna-platform', version: '4.1.0'
     compile group: 'org.terasology', name: 'CrashReporter', version: '1.2.+'
     compile group: 'com.github.rjeschke', name: 'txtmark', version: '0.11'
 
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
+    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.0-alpha5'
+\
     compile group: "com.google.guava", name: "guava", version: "28.1-jre"
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.2'
-    
+
     // For Web API
     // TODO: extract swagger dependencies into swagger.gradle
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.5'
@@ -117,16 +116,24 @@ dependencies {
 
     // These dependencies are only needed for running tests
     testCompile group: 'junit', name: 'junit', version: '4.11'
-    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.26.0'
+    testCompile group: 'org.mockito', name: 'mockito-inline', version: '2.26.0' // For final classes
 
-    // Don't upgrade either of these until https://github.com/powermock/powermock/issues/717 is resolved
-    testCompile 'org.powermock:powermock-module-junit4:1.6.4'
-    testCompile 'org.powermock:powermock-api-mockito:1.6.4'
+    testCompile 'org.powermock:powermock-module-junit4:2.0.4'
+    testCompile 'org.powermock:powermock-api-mockito2:2.0.2'
 }
 
 // Set the expected module Java level (can use a higher Java to run, but should not use features from a higher Java)
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.11
+targetCompatibility = 1.11
+
+javafx {
+    version = "11.0.2"
+    modules = [
+            'javafx.graphics',
+            'javafx.fxml',
+            'javafx.web']
+}
 
 mainClassName = 'org.terasology.launcher.TerasologyLauncher'
 

--- a/config/gradle/jre.gradle
+++ b/config/gradle/jre.gradle
@@ -19,11 +19,10 @@ def jreVersionGame = '8u212'
 def jdkVersionLauncher = '11.0.6+10' // jre version haven't jmod (needed for jlink/jpackager)
 
 def jreUrlFilenames = [
-        Linux64  : 'linux-amd64.tar.gz',
-        Linux32  : 'linux-i586.tar.gz',
-        Windows64: 'windows-amd64.zip',
-        Windows32: 'windows-i586.zip',
-        Mac      : 'macos-amd64.zip'
+        Linux64  : 'linux-amd64-full.tar.gz',
+        Windows64: 'windows-amd64-full.zip',
+        Windows32: 'windows-i586-full.zip',
+        Mac      : 'macos-amd64-full.zip'
 ]
 
 task createRelease() {
@@ -36,21 +35,11 @@ task createRelease() {
     }
 }
 
-task downloadJreGame {
-    group 'Download'
-    description 'Downloads Game JRE for all platforms'
-}
-
-task downloadJreLauncher {
+task downloadJre {
     group 'Download'
     description 'Downloads Launcher JRE for all platforms'
 }
 
-task downloadJreAll {
-    group 'Download'
-    description 'Downloads JRE for all platforms'
-    dependsOn downloadJreGame, downloadJreLauncher
-}
 
 def createJreTasks(String taskNameBase,
                    String downloadUrl,
@@ -83,34 +72,22 @@ def createJreTasks(String taskNameBase,
 }
 
 jreUrlFilenames.each { os, file ->
-    // JRE 8
-    def gameTaskBase = "Jre${os}Game"
-    createJreTasks(
-            gameTaskBase,
-            "https://download.bell-sw.com/java/$jreVersionGame/bellsoft-jre$jreVersionGame-$file",
-            "$projectDir/jre/$os-$jreVersionGame-$file",
-            "$projectDir/jre/Game/$os")
-
-    downloadJreGame.dependsOn "unpack${gameTaskBase}"
-
     // JDK 11
-    def launcherTaskBase = "Jre${os}Launcher"
+    def launcherTaskBase = "Jre${os}"
     createJreTasks(
             launcherTaskBase,
             "https://download.bell-sw.com/java/$jdkVersionLauncher/bellsoft-jdk$jdkVersionLauncher-$file",
             "$projectDir/jre/$os-$jdkVersionLauncher-$file",
-            "$projectDir/jre/Launcher/$os")
-    downloadJreLauncher.dependsOn "unpack${launcherTaskBase}"
-}
-
-jreUrlFilenames.each { os, file ->
+            "$projectDir/jre/$os")
+    downloadJre.dependsOn "unpack${launcherTaskBase}"
     def distName = os.toLowerCase()
     
     distributions {
         "$distName" {
             contents {
-                from "unpackJre${os}Launcher"
-                into 'jre'
+                into ('jre') {
+                    from "$projectDir/jre/$os"
+                }
                 with distributions.main.contents
             }
         }
@@ -119,9 +96,43 @@ jreUrlFilenames.each { os, file ->
     def zipTask = tasks.named("${distName}DistZip").get()
     def tarTask = tasks.named("${distName}DistTar").get()
 
-    zipTask.dependsOn downloadJreAll
+    zipTask.dependsOn downloadJre
     zipTask.description "Bundles the project with a JRE for ${os}"
-    tarTask.dependsOn downloadJreAll
+    tarTask.dependsOn downloadJre
     tarTask.description "Bundles the project with a JRE for ${os}"
     createRelease.dependsOn zipTask
+}
+
+/**
+ * Modify start scripts to use bundled JRE when
+ * available, otherwise fall back to searching.
+ */
+startScripts.doLast {
+    unixScript.text = unixScript
+            .text
+            .replaceFirst(/(?s)# Determine the Java.*(?=\R\R# Increase)/) { match ->
+                """\
+                |# Use bundled JRE when available
+                |if [ -d \$APP_HOME/jre ] ; then
+                |    JAVACMD=\$APP_HOME/jre/bin/java
+                |else
+                |    ${match.replace("\n", "\n    ")}
+                |fi"""
+                .stripMargin()
+            }
+
+    windowsScript.text = windowsScript
+            .text
+            .replaceFirst(/(?s)@rem Find java.*:init/) { match ->
+                """\
+                |@rem Use bundled JRE when available
+                |if not exist %APP_HOME%\\jre\\ goto findJava
+                |set JAVA_EXE=%APP_HOME%\\jre\\bin\\java.exe
+                |goto init
+                |
+                |:findJava
+                |$match
+                |"""
+                .stripMargin()
+            }
 }

--- a/config/gradle/jre.gradle
+++ b/config/gradle/jre.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,15 @@
  */
 
 // Uses Bellsoft Liberica JRE
-def jreVersion = '8u212'
-def jreUrlBase = "https://download.bell-sw.com/java/$jreVersion/bellsoft-jre$jreVersion"
+def jreVersionGame = '8u212'
+def jdkVersionLauncher = '11.0.6+10' // jre version haven't jmod (needed for jlink/jpackager)
+
 def jreUrlFilenames = [
-        Linux64   : 'linux-amd64.tar.gz',
-        Linux32   : 'linux-i586.tar.gz',
-        Windows64 : 'windows-amd64.zip',
-        Windows32 : 'windows-i586.zip',
-        Mac       : 'macos-amd64.zip'
+        Linux64  : 'linux-amd64.tar.gz',
+        Linux32  : 'linux-i586.tar.gz',
+        Windows64: 'windows-amd64.zip',
+        Windows32: 'windows-i586.zip',
+        Mac      : 'macos-amd64.zip'
 ]
 
 task createRelease() {
@@ -35,55 +36,82 @@ task createRelease() {
     }
 }
 
+task downloadJreGame {
+    group 'Download'
+    description 'Downloads Game JRE for all platforms'
+}
+
+task downloadJreLauncher {
+    group 'Download'
+    description 'Downloads Launcher JRE for all platforms'
+}
+
 task downloadJreAll {
     group 'Download'
     description 'Downloads JRE for all platforms'
+    dependsOn downloadJreGame, downloadJreLauncher
+}
+
+def createJreTasks(String taskNameBase,
+                   String downloadUrl,
+                   String downloadFile,
+                   String unpackDir) {
+
+    task "download$taskNameBase"(type: Download) {
+        group 'Download'
+        src downloadUrl
+        dest downloadFile
+        overwrite false
+    }
+
+    task "unpack$taskNameBase"(type: Copy) {
+        from(downloadFile.endsWith("zip")
+                ? zipTree(downloadFile)
+                : tarTree(downloadFile)) {
+            eachFile { fcd ->
+                fcd.relativePath = new RelativePath(
+                        true, fcd.relativePath.segments.drop(1))
+            }
+            includeEmptyDirs = false
+        }
+        into unpackDir
+
+        outputs.dir unpackDir
+
+        dependsOn "download${taskNameBase}"
+    }
 }
 
 jreUrlFilenames.each { os, file ->
-    def packedJre = new File("$projectDir/jre/$file")
-    def unpackedJre = new File("$buildDir/jre/$os")
+    // JRE 8
+    def gameTaskBase = "Jre${os}Game"
+    createJreTasks(
+            gameTaskBase,
+            "https://download.bell-sw.com/java/$jreVersionGame/bellsoft-jre$jreVersionGame-$file",
+            "$projectDir/jre/$os-$jreVersionGame-$file",
+            "$projectDir/jre/Game/$os")
 
-    def downloadTask = task("downloadJre$os") {
-        group 'Download'
-        description "Downloads JRE for $os"
+    downloadJreGame.dependsOn "unpack${gameTaskBase}"
 
-        doFirst {
-            download {
-                src "$jreUrlBase-$file"
-                dest packedJre
-                overwrite false
-            }
-        }
+    // JDK 11
+    def launcherTaskBase = "Jre${os}Launcher"
+    createJreTasks(
+            launcherTaskBase,
+            "https://download.bell-sw.com/java/$jdkVersionLauncher/bellsoft-jdk$jdkVersionLauncher-$file",
+            "$projectDir/jre/$os-$jdkVersionLauncher-$file",
+            "$projectDir/jre/Launcher/$os")
+    downloadJreLauncher.dependsOn "unpack${launcherTaskBase}"
+}
 
-        doLast {
-            // Unpack the JRE
-            if (!unpackedJre.exists()) {
-                unpackedJre.mkdirs()
-                copy {
-                    from(file.endsWith("zip")
-                            ? zipTree(packedJre)
-                            : tarTree(packedJre)) {
-                        eachFile { fcd ->
-                            fcd.relativePath = new RelativePath(
-                                    true, fcd.relativePath.segments.drop(1))
-                        }
-                        includeEmptyDirs = false
-                    }
-                    into unpackedJre
-                }
-            }
-        }
-    }
-
+jreUrlFilenames.each { os, file ->
     def distName = os.toLowerCase()
+    
     distributions {
         "$distName" {
             contents {
+                from "unpackJre${os}Launcher"
+                into 'jre'
                 with distributions.main.contents
-                into('jre') {
-                    from unpackedJre
-                }
             }
         }
     }
@@ -91,44 +119,9 @@ jreUrlFilenames.each { os, file ->
     def zipTask = tasks.named("${distName}DistZip").get()
     def tarTask = tasks.named("${distName}DistTar").get()
 
-    downloadJreAll.dependsOn downloadTask
-    zipTask.dependsOn downloadTask
-    zipTask.description "Bundles the project with a JRE for $os"
-    tarTask.dependsOn downloadTask
-    tarTask.description "Bundles the project with a JRE for $os"
+    zipTask.dependsOn downloadJreAll
+    zipTask.description "Bundles the project with a JRE for ${os}"
+    tarTask.dependsOn downloadJreAll
+    tarTask.description "Bundles the project with a JRE for ${os}"
     createRelease.dependsOn zipTask
-}
-
-/**
- * Modify start scripts to use bundled JRE when
- * available, otherwise fall back to searching.
- */
-startScripts.doLast {
-    unixScript.text = unixScript
-            .text
-            .replaceFirst(/(?s)# Determine the Java.*(?=\R\R# Increase)/) { match ->
-                """\
-                |# Use bundled JRE when available
-                |if [ -d \$APP_HOME/jre ] ; then
-                |    JAVACMD=\$APP_HOME/jre/bin/java
-                |else
-                |    ${match.replace("\n", "\n    ")}
-                |fi"""
-                .stripMargin()
-            }
-
-    windowsScript.text = windowsScript
-            .text
-            .replaceFirst(/(?s)@rem Find java.*:init/) { match ->
-                """\
-                |@rem Use bundled JRE when available
-                |if not exist %APP_HOME%\\jre\\ goto findJava
-                |set JAVA_EXE=%APP_HOME%\\jre\\bin\\java.exe
-                |goto init
-                |
-                |:findJava
-                |$match
-                |"""
-                .stripMargin()
-            }
 }

--- a/src/main/java/org/terasology/launcher/LauncherInitTask.java
+++ b/src/main/java/org/terasology/launcher/LauncherInitTask.java
@@ -78,7 +78,9 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
 
             final boolean serverAvailable = DownloadUtils.isJenkinsAvailable();
             if (serverAvailable && launcherSettings.isSearchForLauncherUpdates()) {
-                final boolean selfUpdaterStarted = checkForLauncherUpdates(downloadDirectory, tempDirectory, launcherSettings.isKeepDownloadedFiles());
+                final boolean selfUpdaterStarted =
+                        checkForLauncherUpdates(downloadDirectory, tempDirectory, launcherSettings.isKeepDownloadedFiles());
+
                 if (selfUpdaterStarted) {
                     logger.info("Exit old TerasologyLauncher: {}", TerasologyLauncherVersionInfo.getInstance());
                     return NullLauncherConfiguration.getInstance();

--- a/src/main/java/org/terasology/launcher/TerasologyLauncher.java
+++ b/src/main/java/org/terasology/launcher/TerasologyLauncher.java
@@ -77,6 +77,7 @@ public final class TerasologyLauncher extends Application {
 
     /**
      * Initialize the host service wrapper by attempting to use the JavaFX {@link HostServices}.
+     *
      * @return the configured host service wrapper
      */
     private HostServicesWrapper initHostServices() {
@@ -85,7 +86,7 @@ public final class TerasologyLauncher extends Application {
             // This may throw an exception on a different thread, but we cannot catch it here o.O
             // In addition, `hostServices` will be initialized, but disfunctional.
             // Thus, we have no idea whether we can use the services or not...
-             hs = getHostServices();
+            hs = getHostServices();
             // poor man's check: this will throw a NPE if the internal `hostServices.delegate` is not initialized
             hs.getCodeBase();
         } catch (NullPointerException e) {
@@ -153,7 +154,7 @@ public final class TerasologyLauncher extends Application {
             }
             //TODO: Should we really crash here? The task state is set to "failed" if an exception is thrown, even if
             //      it is caught...
-            // openCrashReporterAndExit(exception);
+            openCrashReporterAndExit(exception);
         });
 
         initThread.start();
@@ -176,9 +177,13 @@ public final class TerasologyLauncher extends Application {
     private void openCrashReporterAndExit(Exception e) {
         logger.error("The TerasologyLauncher could not be started!");
 
-        Path logFile = TempLogFilePropertyDefiner.getInstance().getLogFile();
-        //TODO: this hangs on Java 11 instead of showing the CrashReporter
-        // CrashReporter.report(e, logFile);
+        TempLogFilePropertyDefiner tempLogFileDefiner = TempLogFilePropertyDefiner.getInstance();
+
+        Path logFile = null;
+        if (tempLogFileDefiner != null) { // for dev run
+            logFile = tempLogFileDefiner.getLogFile();
+        }
+        CrashReporter.report(e, logFile);
         System.exit(1);
     }
 

--- a/src/main/java/org/terasology/launcher/TerasologyLauncher.java
+++ b/src/main/java/org/terasology/launcher/TerasologyLauncher.java
@@ -121,6 +121,8 @@ public final class TerasologyLauncher extends Application {
 
         showSplashStage(initialStage, launcherInitTask);
         Thread initThread = new Thread(launcherInitTask);
+        initThread.setName("Launcher init thread");
+        initThread.setUncaughtExceptionHandler((t, e) -> logger.warn("Initialization failed!", e));
 
         launcherInitTask.setOnSucceeded(new EventHandler<WorkerStateEvent>() {
             @Override
@@ -139,6 +141,19 @@ public final class TerasologyLauncher extends Application {
                     openCrashReporterAndExit(e);
                 }
             }
+        });
+
+        launcherInitTask.setOnFailed(event -> {
+            Throwable throwable = event.getSource().getException();
+            Exception exception;
+            if (throwable instanceof Exception) {
+                exception = (Exception) throwable;
+            } else {
+                exception = new Exception("Wrapped throwable, see deeper", throwable);
+            }
+            //TODO: Should we really crash here? The task state is set to "failed" if an exception is thrown, even if
+            //      it is caught...
+            // openCrashReporterAndExit(exception);
         });
 
         initThread.start();
@@ -162,7 +177,8 @@ public final class TerasologyLauncher extends Application {
         logger.error("The TerasologyLauncher could not be started!");
 
         Path logFile = TempLogFilePropertyDefiner.getInstance().getLogFile();
-        CrashReporter.report(e, logFile);
+        //TODO: this hangs on Java 11 instead of showing the CrashReporter
+        // CrashReporter.report(e, logFile);
         System.exit(1);
     }
 
@@ -183,7 +199,7 @@ public final class TerasologyLauncher extends Application {
         }
         final ApplicationController controller = fxmlLoader.getController();
         controller.update(launcherConfiguration.getLauncherDirectory(), launcherConfiguration.getDownloadDirectory(), launcherConfiguration.getTempDirectory(),
-            launcherConfiguration.getLauncherSettings(), launcherConfiguration.getPackageManager(), mainStage, hostServices);
+                launcherConfiguration.getLauncherSettings(), launcherConfiguration.getPackageManager(), mainStage, hostServices);
 
         Scene scene = new Scene(root);
         scene.getStylesheets().add(BundleUtils.getStylesheet("css_terasology"));

--- a/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/gui/javafx/ApplicationController.java
@@ -16,7 +16,6 @@
 
 package org.terasology.launcher.gui.javafx;
 
-import com.sun.javafx.scene.control.skin.ComboBoxListViewSkin;
 import javafx.animation.Transition;
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
@@ -463,19 +462,6 @@ public class ApplicationController {
         jobBox.getSelectionModel().select(0);
     }
 
-    /**
-     * Workaround to reset the scroll bar of the given ComboBox to either the selected index or the first element.
-     * <p>
-     * Code taken from: https://stackoverflow.com/a/57885977
-     *
-     * @param cb The {@link ComboBox} to reset the scroll bar for.
-     */
-    private void resetScrollBar(final ComboBox cb) {
-        // Beware: type of skin is an implementation detail!
-        ListView list = (ListView) ((ComboBoxListViewSkin) cb.getSkin()).getPopupContent();
-        list.scrollTo(Math.max(0, cb.getSelectionModel().getSelectedIndex()));
-    }
-
     private void initComboBoxes() {
         jobBox.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) -> {
             buildVersionBox.setItems(newVal.versionItems);
@@ -483,7 +469,6 @@ public class ApplicationController {
             buildVersionBox.getSelectionModel().select(0);
         });
 
-        buildVersionBox.setOnShowing(e -> resetScrollBar(buildVersionBox));
         buildVersionBox.setCellFactory(list -> new VersionListCell());
         buildVersionBox.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) -> {
             if (newVal == null) {

--- a/src/main/java/org/terasology/launcher/packages/PackageDatabase.java
+++ b/src/main/java/org/terasology/launcher/packages/PackageDatabase.java
@@ -65,9 +65,13 @@ class PackageDatabase {
                 new InputStreamReader(Files.newInputStream(sourcesFile))
         )) {
             final List<Package> newDatabase = new LinkedList<>();
-            for (Repository source : gson.fromJson(reader, Repository[].class)) {
-                logger.trace("Fetching package list from: {}", source.url);
-                newDatabase.addAll(packageListOf(source));
+            try {
+                for (Repository source : gson.fromJson(reader, Repository[].class)) {
+                    logger.trace("Fetching package list from: {}", source.url);
+                    newDatabase.addAll(packageListOf(source));
+                }
+            } catch (IllegalStateException e) {
+                logger.error("Could not read repositories from '%s'", sourcesFile, e);
             }
 
             database.clear();

--- a/src/main/java/org/terasology/launcher/settings/BaseLauncherSettings.java
+++ b/src/main/java/org/terasology/launcher/settings/BaseLauncherSettings.java
@@ -41,7 +41,7 @@ import java.util.Properties;
 @Deprecated
 public final class BaseLauncherSettings extends AbstractLauncherSettings {
 
-    public static final String USER_JAVA_PARAMETERS_DEFAULT = "-XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:MaxGCPauseMillis=20 -XX:ParallelGCThreads=10";
+    public static final String USER_JAVA_PARAMETERS_DEFAULT = "-XX:+UseParallelGC -XX:MaxGCPauseMillis=20 -XX:ParallelGCThreads=10";
     public static final String USER_GAME_PARAMETERS_DEFAULT = "";
 
     public static final String PROPERTY_LOCALE = "locale";

--- a/src/main/java/org/terasology/launcher/updater/LauncherUpdater.java
+++ b/src/main/java/org/terasology/launcher/updater/LauncherUpdater.java
@@ -78,8 +78,8 @@ public final class LauncherUpdater {
      * @return whether an update is available
      */
     public boolean updateAvailable() {
-        if (this.currentVersionInfo.isEmpty()) {
-            logger.trace("Skipping update check - no version info file found (assuming development environment)");
+        if (this.currentVersionInfo.isEmpty() || jobName.equals("null")) {
+            logger.trace("Skipping update check - no version info file or jobname found (assuming development environment)");
             return false;
         }
 

--- a/src/main/java/org/terasology/launcher/util/DownloadUtils.java
+++ b/src/main/java/org/terasology/launcher/util/DownloadUtils.java
@@ -30,6 +30,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/src/test/java/org/terasology/launcher/TestingUtils.java
+++ b/src/test/java/org/terasology/launcher/TestingUtils.java
@@ -24,9 +24,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.anyString;
 
 public final class TestingUtils {
 
@@ -62,11 +62,11 @@ public final class TestingUtils {
             latestBuilds.put(entry.getKey(), Collections.max(entry.getValue().keySet()));
         }
 
-        PowerMockito.doAnswer((i) -> latestBuilds.get(i.getArgumentAt(0, String.class))).
+        PowerMockito.doAnswer((i) -> latestBuilds.get(i.getArgument(0, String.class))).
                 when(DownloadUtils.class, "loadBuildNumberJenkins", anyString(), anyString());
 
         PowerMockito.doAnswer((i) ->
-                buildValues.hasEntry(i.getArgumentAt(0, String.class), i.getArgumentAt(1, Integer.class)) ? JobResult.SUCCESS : JobResult.NOT_BUILT)
+                buildValues.hasEntry(i.getArgument(0, String.class), i.getArgument(1, Integer.class)) ? JobResult.SUCCESS : JobResult.NOT_BUILT)
                 .when(DownloadUtils.class, "loadJobResultJenkins", anyString(), anyInt());
 
         PowerMockito.doReturn(null).when(DownloadUtils.class, "loadChangeLogJenkins", anyString(), anyInt());
@@ -74,8 +74,8 @@ public final class TestingUtils {
         // Omega trigger
         // This lambda simulates the behavior of an actual Jenkins server, mapping an omega build number to a 'linked' normal build
         PowerMockito.doAnswer((i) -> {
-            GameJob job = i.getArgumentAt(0, GameJob.class);
-            int omegaBuildNumber = i.getArgumentAt(1, int.class);
+            GameJob job = i.getArgument(0, GameJob.class);
+            int omegaBuildNumber = i.getArgument(1, Integer.class);
             return buildValues.getNormalFromOmega(job.name(), omegaBuildNumber);
         }).when(DownloadUtils.class, "loadEngineTriggerJenkins", anyObject(), anyInt());
     }

--- a/src/test/java/org/terasology/launcher/game/TestGameRunner.java
+++ b/src/test/java/org/terasology/launcher/game/TestGameRunner.java
@@ -18,9 +18,9 @@ package org.terasology.launcher.game;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.eq;
@@ -82,13 +82,13 @@ public class TestGameRunner {
         gameRunner.run();
 
         // Make sure GameRunner logs TEST_STRING line 1
-        verify((Logger) Whitebox.getInternalState(gameRunner, "logger")).trace(
+        verify((Logger) Whitebox.getInternalState(GameRunner.class, "logger")).trace(
                 "Game output: {}",
                 testString.substring(0, testString.indexOf("\n"))
         );
 
         // Make sure GameRunner logs TEST_STRING line 2
-        verify((Logger) Whitebox.getInternalState(gameRunner, "logger")).trace(
+        verify((Logger) Whitebox.getInternalState(GameRunner.class, "logger")).trace(
                 "Game output: {}",
                 testString.substring(testString.indexOf("\n") + 1)
         );
@@ -103,7 +103,7 @@ public class TestGameRunner {
         gameRunner.run();
 
         // Make sure GameRunner logs that the game exited
-        verify((Logger) Whitebox.getInternalState(gameRunner, "logger"), atLeastOnce()).debug(
+        verify((Logger) Whitebox.getInternalState(GameRunner.class, "logger"), atLeastOnce()).debug(
                 "Game closed with the exit value '{}'.",
                 0
         );
@@ -126,7 +126,7 @@ public class TestGameRunner {
         gameRunner.run();
 
         // Make sure GameRunner logs that the game thread was interrupted
-        verify((Logger) Whitebox.getInternalState(gameRunner, "logger")).debug("Game thread interrupted.");
+        verify((Logger) Whitebox.getInternalState(GameRunner.class, "logger")).debug("Game thread interrupted.");
     }
 
     @Test
@@ -141,7 +141,7 @@ public class TestGameRunner {
         gameRunner.run();
 
         // Make sure GameRunner logs an error with an InterruptedException
-        verify((Logger) Whitebox.getInternalState(gameRunner, "logger")).error(eq("The game thread was interrupted!"), any(InterruptedException.class));
+        verify((Logger) Whitebox.getInternalState(GameRunner.class, "logger")).error(eq("The game thread was interrupted!"), any(InterruptedException.class));
     }
 
     @Test
@@ -159,6 +159,6 @@ public class TestGameRunner {
         gameRunner.run();
 
         // Make sure GameRunner logs an error with an IOException
-        verify((Logger) Whitebox.getInternalState(gameRunner, "logger")).error(eq("Could not read game output!"), any(IOException.class));
+        verify((Logger) Whitebox.getInternalState(GameRunner.class, "logger")).error(eq("Could not read game output!"), any(IOException.class));
     }
 }

--- a/src/test/java/org/terasology/launcher/game/TestGameVersions.java
+++ b/src/test/java/org/terasology/launcher/game/TestGameVersions.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.terasology.launcher.TestingUtils;
@@ -34,11 +35,12 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.IntStream;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.powermock.api.mockito.PowerMockito.spy;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({DownloadUtils.class, TerasologyGameVersions.class})
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
 public class TestGameVersions {
 
     // These functions are common assertions, to be used with requireAssertions
@@ -200,7 +202,7 @@ public class TestGameVersions {
         // We suppress fetching the game version info, so that the test doesn't depend on the network
         // and is deterministic
         PowerMockito.doAnswer((i) -> {
-            TerasologyGameVersion version = i.getArgumentAt(0, TerasologyGameVersion.class);
+            TerasologyGameVersion version = i.getArgument(0, TerasologyGameVersion.class);
             version.setGameVersionInfo(TerasologyGameVersionInfo.getEmptyGameVersionInfo());
             return null;
         }).when(gameVersions, "loadAndSetGameVersionInfo", any(), any(), any(), any());

--- a/src/test/java/org/terasology/launcher/updater/TestLancherUpdater.java
+++ b/src/test/java/org/terasology/launcher/updater/TestLancherUpdater.java
@@ -19,6 +19,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.terasology.launcher.TestingUtils;
@@ -34,6 +35,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({DownloadUtils.class, LauncherUpdater.class})
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
 public final class TestLancherUpdater {
 
     private static String buildNumber;

--- a/src/test/java/org/terasology/launcher/util/TestFileUtils.java
+++ b/src/test/java/org/terasology/launcher/util/TestFileUtils.java
@@ -164,38 +164,6 @@ public class TestFileUtils {
     }
 
     @Test
-    public void testExtract() throws IOException {
-        final String fileInRoot = "fileInRoot";
-        final String fileInFolder = "folder/fileInFolder";
-        final String file1Contents = SAMPLE_TEXT + "1";
-        final String file2Contents = SAMPLE_TEXT + "2";
-        /* An archive with this structure is created:
-         * <zip root>
-         * +-- fileInRoot
-         * +-- folder
-         * |   +-- fileInFolder
-         */
-        Path zipFile = tempFolder.newFile(FILE_NAME + ".zip").toPath();
-        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(zipFile))) {
-            zipOutputStream.putNextEntry(new ZipEntry(fileInRoot));
-            zipOutputStream.write(file1Contents.getBytes());
-            zipOutputStream.closeEntry();
-            zipOutputStream.putNextEntry(new ZipEntry(fileInFolder));
-            zipOutputStream.write(file2Contents.getBytes());
-            zipOutputStream.closeEntry();
-        }
-
-        Path outputDir = tempFolder.newFolder().toPath();
-        FileUtils.extractZipTo(zipFile, outputDir);
-        Path extractedFileInRoot = outputDir.resolve(fileInRoot);
-        Path extractedFileInFolder = outputDir.resolve(fileInFolder);
-        assertTrue(Files.exists(extractedFileInRoot));
-        assertTrue(Files.exists(extractedFileInFolder));
-        assertEquals(file1Contents, Files.readAllLines(extractedFileInRoot).get(0));
-        assertEquals(file2Contents, Files.readAllLines(extractedFileInFolder).get(0));
-    }
-
-    @Test
     public void testDeleteFileSilently() throws IOException {
         Path tempFile = tempFolder.newFile(FILE_NAME).toPath();
         assertTrue(Files.exists(tempFile));

--- a/src/test/java/org/terasology/launcher/util/TestFileUtils.java
+++ b/src/test/java/org/terasology/launcher/util/TestFileUtils.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -42,6 +43,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(FileUtils.class)
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
 public class TestFileUtils {
 
     private static final String FILE_NAME = "File";

--- a/src/test/java/org/terasology/launcher/util/TestFileUtilsNoMock.java
+++ b/src/test/java/org/terasology/launcher/util/TestFileUtilsNoMock.java
@@ -1,0 +1,59 @@
+package org.terasology.launcher.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Power mock trying make public all methods from jdk.nio.zipfs. that restricted and not needed (deleteFile)
+ */
+public class TestFileUtilsNoMock {
+
+    private static final String FILE_NAME = "File";
+    private static final String SAMPLE_TEXT = "Lorem Ipsum";
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void testExtract() throws IOException {
+        final String fileInRoot = "fileInRoot";
+        final String fileInFolder = "folder/fileInFolder";
+        final String file1Contents = SAMPLE_TEXT + "1";
+        final String file2Contents = SAMPLE_TEXT + "2";
+        /* An archive with this structure is created:
+         * <zip root>
+         * +-- fileInRoot
+         * +-- folder
+         * |   +-- fileInFolder
+         */
+        Path zipFile = tempFolder.newFile(FILE_NAME + ".zip").toPath();
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(zipFile))) {
+            zipOutputStream.putNextEntry(new ZipEntry(fileInRoot));
+            zipOutputStream.write(file1Contents.getBytes());
+            zipOutputStream.closeEntry();
+            zipOutputStream.putNextEntry(new ZipEntry(fileInFolder));
+            zipOutputStream.write(file2Contents.getBytes());
+            zipOutputStream.closeEntry();
+        }
+
+        Path outputDir = tempFolder.newFolder().toPath();
+        FileUtils.extractZipTo(zipFile, outputDir);
+        Path extractedFileInRoot = outputDir.resolve(fileInRoot);
+        Path extractedFileInFolder = outputDir.resolve(fileInFolder);
+        assertTrue(Files.exists(extractedFileInRoot));
+        assertTrue(Files.exists(extractedFileInFolder));
+        assertEquals(file1Contents, Files.readAllLines(extractedFileInRoot).get(0));
+        assertEquals(file2Contents, Files.readAllLines(extractedFileInFolder).get(0));
+    }
+
+}

--- a/src/test/java/org/terasology/launcher/util/TestLauncherDirectoryUtils.java
+++ b/src/test/java/org/terasology/launcher/util/TestLauncherDirectoryUtils.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -35,6 +36,7 @@ import static org.terasology.launcher.util.LauncherDirectoryUtils.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(LauncherDirectoryUtils.class)
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
 public class TestLauncherDirectoryUtils {
 
     @Rule

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
### Contains

Pure upgrade to Java 11.
Uses Full version of Liberica JDK 11.
Uses it for Terasology engine too.

### How to test

Try any launcher feature.

### Outstanding before merging

- [ ] We have some problem with old settings. 
       Java 11 haven't jvm args: -XX:+UseParNewGC -XX:+UseConcMarkSweepGC.
       And game cannot launch , if you not change saved settings.
- [ ] Remove openJFX's libs from distributions with JDK, or change JDK to minimal version and add openJFX libs to platform-specific distributions