### PR TITLE
fix(buildres): linux run script

### DIFF
--- a/buildres/linux/TerasologyLauncher.run
+++ b/buildres/linux/TerasologyLauncher.run
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
-echo "Starting TerasologyLauncher from './bin/TerasologyLauncher'"
-sh ./bin/TerasologyLauncher
+BASE_DIR=$(dirname "$0")
+echo "Starting TerasologyLauncher from '${BASE_DIR}/bin/TerasologyLauncher'"
+sh ${BASE_DIR}/bin/TerasologyLauncher


### PR DESCRIPTION
- TerasologyLauncher.run used hardcoded `./bin/TersologyLauncher` to start the launcher
- this fails if outside the launcher installation directory
- detecting and using the base dir with `$(dirname "$0")` fixes this
