### PR TITLE
chore: add PLATFORM to versionInfo file

### DIFF
--- a/.github/workflows/asset-upload.yml
+++ b/.github/workflows/asset-upload.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PLATFORM: ${{ matrix.platform }}
         with:
           # This pulls from the RELEASE event this workflow was triggered by.
           # See https://developer.github.com/v3/activity/events/types/#releaseevent

--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,15 @@ def convertGitBranch = { gitBranch ->
     }
 }
 
+/**
+ * Create an entry for a `.properties` file if the value is not null.
+ *
+ * @return an `ant.entry` to be used with `ant.propertyfile`
+ */
+def propertyEntry(key, value) {
+    (value != null) ? ant.entry(key: key, value: value) : null
+}
+
 task createVersionInfoFile {
 
     inputs.property('version', version.toString())
@@ -146,15 +155,17 @@ task createVersionInfoFile {
     doLast {
         versionInfoFileDir.mkdirs()
         ant.propertyfile(file: versionInfoFile) {
-            ant.entry(key: 'buildNumber', value: env.BUILD_NUMBER)
-            ant.entry(key: 'buildId', value: env.BUILD_ID)
-            ant.entry(key: 'buildTag', value: env.BUILD_TAG)
-            ant.entry(key: 'buildUrl', value: env.BUILD_URL)
-            ant.entry(key: 'jobName', value: env.JOB_NAME)
-            ant.entry(key: 'gitBranch', value: convertGitBranch(env.GIT_BRANCH))
-            ant.entry(key: 'gitCommit', value: env.GIT_COMMIT)
-            ant.entry(key: 'dateTime', value: startDateTimeString)
-            ant.entry(key: 'displayVersion', value: displayVersion)
+            propertyEntry('buildNumber', env.BUILD_NUMBER)
+            propertyEntry('buildId', env.BUILD_ID)
+            propertyEntry('buildTag', env.BUILD_TAG)
+            propertyEntry('buildUrl',  env.BUILD_URL)
+            propertyEntry('jobName',  env.JOB_NAME)
+            propertyEntry('gitBranch', convertGitBranch(env.GIT_BRANCH))
+            propertyEntry('gitCommit', env.GIT_COMMIT)
+            propertyEntry('dateTime', startDateTimeString)
+            propertyEntry('displayVersion', displayVersion)
+            propertyEntry('version', version.toString())
+            propertyEntry('platform', env.PLATFORM)
         }
     }
 }

--- a/src/main/java/org/terasology/launcher/version/TerasologyLauncherVersionInfo.java
+++ b/src/main/java/org/terasology/launcher/version/TerasologyLauncherVersionInfo.java
@@ -38,6 +38,8 @@ public final class TerasologyLauncherVersionInfo {
     private static final String GIT_COMMIT = "gitCommit";
     private static final String DATE_TIME = "dateTime";
     private static final String DISPLAY_VERSION = "displayVersion";
+    private static final String SEMVER_VERSION = "version";
+    private static final String PLATFORM = "platform";
 
     private static final String DEFAULT_VALUE = "";
 
@@ -54,7 +56,9 @@ public final class TerasologyLauncherVersionInfo {
     private final String gitCommit;
     private final String dateTime;
     private final String displayVersion;
+    private final String version;
     private final String stringRepresentation;
+    private final String platform;
 
     private TerasologyLauncherVersionInfo(Properties versionInfoProperties) {
         final Properties properties;
@@ -74,6 +78,8 @@ public final class TerasologyLauncherVersionInfo {
         gitCommit = properties.getProperty(GIT_COMMIT, DEFAULT_VALUE);
         dateTime = properties.getProperty(DATE_TIME, DEFAULT_VALUE);
         displayVersion = properties.getProperty(DISPLAY_VERSION, DEFAULT_VALUE);
+        version = properties.getProperty(SEMVER_VERSION, DEFAULT_VALUE);
+        platform = properties.getProperty(PLATFORM);
 
         final StringBuilder stringRepresentationBuilder = new StringBuilder();
         stringRepresentationBuilder.append("[");
@@ -113,6 +119,10 @@ public final class TerasologyLauncherVersionInfo {
         stringRepresentationBuilder.append("=");
         stringRepresentationBuilder.append(displayVersion);
         stringRepresentationBuilder.append(", ");
+        stringRepresentationBuilder.append(SEMVER_VERSION);
+        stringRepresentationBuilder.append("=");
+        stringRepresentationBuilder.append(version);
+        stringRepresentationBuilder.append(", ");
         stringRepresentationBuilder.append("isEmpty");
         stringRepresentationBuilder.append("=");
         stringRepresentationBuilder.append(isEmpty);
@@ -121,12 +131,15 @@ public final class TerasologyLauncherVersionInfo {
         stringRepresentation = stringRepresentationBuilder.toString();
     }
 
+    //TODO: why does this need to be a singleton?
     public static synchronized TerasologyLauncherVersionInfo getInstance() {
         if (instance == null) {
             instance = new TerasologyLauncherVersionInfo(null);
         }
         return instance;
     }
+
+    //TODO: return `Optional<String>` and get rid of `isEmpty`
 
     public static TerasologyLauncherVersionInfo loadFromInputStream(InputStream inStream) {
         return new TerasologyLauncherVersionInfo(loadPropertiesFromInputStream(inStream));
@@ -155,40 +168,16 @@ public final class TerasologyLauncherVersionInfo {
         return isEmpty;
     }
 
-    public String getBuildNumber() {
-        return buildNumber;
-    }
-
-    public String getBuildId() {
-        return buildId;
-    }
-
-    public String getBuildTag() {
-        return buildTag;
-    }
-
-    public String getBuildUrl() {
-        return buildUrl;
-    }
-
-    public String getJobName() {
-        return jobName;
-    }
-
-    public String getGitBranch() {
-        return gitBranch;
-    }
-
-    public String getGitCommit() {
-        return gitCommit;
-    }
-
-    public String getDateTime() {
-        return dateTime;
-    }
-
     public String getDisplayVersion() {
         return displayVersion;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getPlatform() {
+        return platform;
     }
 
     @Override

--- a/src/main/java/org/terasology/launcher/version/TerasologyLauncherVersionInfo.java
+++ b/src/main/java/org/terasology/launcher/version/TerasologyLauncherVersionInfo.java
@@ -123,6 +123,10 @@ public final class TerasologyLauncherVersionInfo {
         stringRepresentationBuilder.append("=");
         stringRepresentationBuilder.append(version);
         stringRepresentationBuilder.append(", ");
+        stringRepresentationBuilder.append(PLATFORM);
+        stringRepresentationBuilder.append("=");
+        stringRepresentationBuilder.append(platform);
+        stringRepresentationBuilder.append(", ");
         stringRepresentationBuilder.append("isEmpty");
         stringRepresentationBuilder.append("=");
         stringRepresentationBuilder.append(isEmpty);
@@ -168,6 +172,14 @@ public final class TerasologyLauncherVersionInfo {
         return isEmpty;
     }
 
+    public String getBuildNumber() {
+        return buildNumber;
+    }
+
+    public String getJobName() {
+        return jobName;
+    }
+
     public String getDisplayVersion() {
         return displayVersion;
     }
@@ -184,4 +196,5 @@ public final class TerasologyLauncherVersionInfo {
     public String toString() {
         return stringRepresentation;
     }
+
 }


### PR DESCRIPTION
Extracted from #521 

This prepares the launcher to know for which platform it was built. To include that information in a local build run the following (replacing the value with the platform/architecture of your choice):

```bash
export PLATFORM=linux64
./gradlew linux64DistZip
```