### PR TITLE
Provide platform name to self-updater

### DIFF
--- a/src/main/java/org/terasology/launcher/LauncherInitTask.java
+++ b/src/main/java/org/terasology/launcher/LauncherInitTask.java
@@ -193,10 +193,24 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
     }
 
     private boolean checkForLauncherUpdates(OperatingSystem os, Path downloadDirectory, Path tempDirectory, boolean saveDownloadedFiles) {
+        final boolean is64Bit = System.getProperty("os.arch").contains("64");
+        final String platform;
+        if (os.isWindows() && is64Bit) {
+            platform = "windows64";
+        } else if (os.isMac()) {
+            platform = "mac";
+        } else if (os == OperatingSystem.LINUX && is64Bit) {
+            platform = "linux64";
+        } else {
+            logger.warn("Self-updates are not supported for the current platform: {} {}-bit",
+                    System.getProperty("os.name"), is64Bit ? "64" : "32");
+            return false;
+        }
+
         logger.trace("Check for launcher updates...");
         boolean selfUpdaterStarted = false;
         updateMessage(BundleUtils.getLabel("splash_launcherUpdateCheck"));
-        final LauncherUpdater updater = new LauncherUpdater(os, TerasologyLauncherVersionInfo.getInstance());
+        final LauncherUpdater updater = new LauncherUpdater(platform, TerasologyLauncherVersionInfo.getInstance());
         final GitHubRelease release = updater.updateAvailable();
         if (release != null) {
             logger.info("Launcher update available: {}", release.getTagName());

--- a/src/main/java/org/terasology/launcher/LauncherInitTask.java
+++ b/src/main/java/org/terasology/launcher/LauncherInitTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
 
             final boolean serverAvailable = DownloadUtils.isJenkinsAvailable();
             if (serverAvailable && launcherSettings.isSearchForLauncherUpdates()) {
-                final boolean selfUpdaterStarted = checkForLauncherUpdates(downloadDirectory, tempDirectory, launcherSettings.isKeepDownloadedFiles());
+                final boolean selfUpdaterStarted = checkForLauncherUpdates(os, downloadDirectory, tempDirectory, launcherSettings.isKeepDownloadedFiles());
                 if (selfUpdaterStarted) {
                     logger.info("Exit old TerasologyLauncher: {}", TerasologyLauncherVersionInfo.getInstance());
                     return NullLauncherConfiguration.getInstance();
@@ -192,11 +192,11 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
         return launcherSettings;
     }
 
-    private boolean checkForLauncherUpdates(Path downloadDirectory, Path tempDirectory, boolean saveDownloadedFiles) {
+    private boolean checkForLauncherUpdates(OperatingSystem os, Path downloadDirectory, Path tempDirectory, boolean saveDownloadedFiles) {
         logger.trace("Check for launcher updates...");
         boolean selfUpdaterStarted = false;
         updateMessage(BundleUtils.getLabel("splash_launcherUpdateCheck"));
-        final LauncherUpdater updater = new LauncherUpdater(TerasologyLauncherVersionInfo.getInstance());
+        final LauncherUpdater updater = new LauncherUpdater(os, TerasologyLauncherVersionInfo.getInstance());
         final GitHubRelease release = updater.updateAvailable();
         if (release != null) {
             logger.info("Launcher update available: {}", release.getTagName());

--- a/src/main/java/org/terasology/launcher/github/GitHubRelease.java
+++ b/src/main/java/org/terasology/launcher/github/GitHubRelease.java
@@ -52,10 +52,13 @@ public class GitHubRelease {
         return json.getString("body");
     }
 
-    public boolean hasAssetFor(String platform) {
+    public String getDownloadUrl(String platform) {
         return json.getJsonArray("assets")
                 .stream()
                 .map(JsonValue::asJsonObject)
-                .anyMatch(asset -> asset.getString("name").contains(platform));
+                .filter(asset -> asset.getString("name").contains(platform))
+                .findFirst()
+                .map(asset -> asset.getString("browser_download_url"))
+                .orElseThrow(() -> new IllegalArgumentException("Invalid platform")); // Should not reach
     }
 }

--- a/src/main/java/org/terasology/launcher/github/GitHubRelease.java
+++ b/src/main/java/org/terasology/launcher/github/GitHubRelease.java
@@ -20,6 +20,11 @@ package org.terasology.launcher.github;
 import com.google.common.base.Preconditions;
 
 import javax.json.JsonObject;
+import javax.json.JsonValue;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Simplified interface for GitHub releases.
@@ -45,5 +50,12 @@ public class GitHubRelease {
 
     public String getBody() {
         return json.getString("body");
+    }
+
+    public boolean hasAssetFor(String platform) {
+        return json.getJsonArray("assets")
+                .stream()
+                .map(JsonValue::asJsonObject)
+                .anyMatch(asset -> asset.getString("name").contains(platform));
     }
 }

--- a/src/main/java/org/terasology/launcher/updater/LauncherUpdater.java
+++ b/src/main/java/org/terasology/launcher/updater/LauncherUpdater.java
@@ -48,16 +48,8 @@ public final class LauncherUpdater {
 
     private Path launcherInstallationDirectory;
 
-    public LauncherUpdater(OperatingSystem os, TerasologyLauncherVersionInfo currentVersionInfo) {
-        if (os.isWindows()) {
-            currentPlatform = "windows64";
-        } else if (os.isMac()) {
-            currentPlatform = "mac";
-        } else if (os.isUnix()) {
-            currentPlatform = "linux64";
-        } else {
-            currentPlatform = null;
-        }
+    public LauncherUpdater(String currentPlatform, TerasologyLauncherVersionInfo currentVersionInfo) {
+        this.currentPlatform = currentPlatform;
         github = new GitHubClient();
         //TODO: might not be valid semver, catch or use Try<..>
         currentVersion = new Semver(currentVersionInfo.getVersion());

--- a/src/main/java/org/terasology/launcher/updater/LauncherUpdater.java
+++ b/src/main/java/org/terasology/launcher/updater/LauncherUpdater.java
@@ -42,14 +42,12 @@ public final class LauncherUpdater {
 
     private static final Logger logger = LoggerFactory.getLogger(LauncherUpdater.class);
 
-    private final String currentPlatform;
     private final Semver currentVersion;
     private final GitHubClient github;
 
     private Path launcherInstallationDirectory;
 
-    public LauncherUpdater(String currentPlatform, TerasologyLauncherVersionInfo currentVersionInfo) {
-        this.currentPlatform = currentPlatform;
+    public LauncherUpdater(TerasologyLauncherVersionInfo currentVersionInfo) {
         github = new GitHubClient();
         //TODO: might not be valid semver, catch or use Try<..>
         currentVersion = new Semver(currentVersionInfo.getVersion());
@@ -73,8 +71,7 @@ public final class LauncherUpdater {
         try {
             final GitHubRelease latestRelease = github.getLatestRelease("movingblocks", "terasologylauncher");
 
-            if (versionOf(latestRelease).isGreaterThan(currentVersion)
-                    && latestRelease.hasAssetFor(currentPlatform)) {
+            if (versionOf(latestRelease).isGreaterThan(currentVersion)) {
                 return latestRelease;
             }
         } catch (IOException e) {
@@ -83,7 +80,7 @@ public final class LauncherUpdater {
         return null;
     }
 
-    public boolean showUpdateDialog(Stage parentStage, final GitHubRelease release) {
+    public boolean confirmUpdate(Stage parentStage, final GitHubRelease release) {
         FutureTask<Boolean> dialog = getUpdateDialog(parentStage, release);
 
         Platform.runLater(dialog);


### PR DESCRIPTION
This allows the self-updater to receive the name of the current platform, so it can download the correct assets from GitHub. It reuses the `OperatingSystem` detected during `LauncherInitTask` to know the platform name. Fixes #528.