### PR TITLE
fix: Don't block the application thread on message dialog

### DIFF
--- a/src/main/java/org/terasology/launcher/util/GuiUtils.java
+++ b/src/main/java/org/terasology/launcher/util/GuiUtils.java
@@ -52,11 +52,6 @@ public final class GuiUtils {
         });
 
         Platform.runLater(dialog);
-        try {
-            dialog.get();
-        } catch (InterruptedException | ExecutionException e) {
-            logger.warn("Uh oh, something went wrong with the dialog!", e);
-        }
     }
 
     public static void showWarningMessageDialog(Stage owner, String message) {


### PR DESCRIPTION
Fixes #551. 

Though note this PR changes the method used by *all* showMessageDialog callers, not just that one about starting the game.

### How to test

1. In Settings / Advanced Options, add some nonsense like `-XX:+PleaseCrash💥` to Java Arguments.
2. Run the game. (download first, if necessary.)
3. After five seconds, you should see a dialog pop up saying "Could not start the game!"
4. After dismissing that dialog the application should respond as normal. (can select menus, switch between tabs, etc.)
