### PR TITLE
fix: Remove unitialized variable in LauncherUpdater

### DIFF
--- a/src/main/java/org/terasology/launcher/updater/LauncherUpdater.java
+++ b/src/main/java/org/terasology/launcher/updater/LauncherUpdater.java
@@ -44,8 +44,6 @@ public final class LauncherUpdater {
     private final Semver currentVersion;
     private final GitHubClient github;
 
-    private Path launcherInstallationDirectory;
-
     public LauncherUpdater(TerasologyLauncherVersionInfo currentVersionInfo) {
         github = new GitHubClient();
         //TODO: might not be valid semver, catch or use Try<..>
@@ -94,23 +92,16 @@ public final class LauncherUpdater {
     }
 
     private FutureTask<Boolean> getUpdateDialog(Stage parentStage, GitHubRelease release) {
-        final String infoText = new StringBuilder()
-                .append("  ")
-                .append(BundleUtils.getLabel("message_update_current"))
-                .append("  ")
-                .append(currentVersion.getValue())
-                .append("  \n")
-                .append("  ")
-                .append(BundleUtils.getLabel("message_update_latest"))
-                .append("  ")
-                .append(versionOf(release).getValue())
-                .append("  \n")
-                .append("  ")
-                .append(BundleUtils.getLabel("message_update_installationDirectory"))
-                .append("  ")
-                .append(launcherInstallationDirectory.toString())
-                .append("  ")
-                .toString();
+        final String infoText = "  " +
+                BundleUtils.getLabel("message_update_current") +
+                "  " +
+                currentVersion.getValue() +
+                "  \n" +
+                "  " +
+                BundleUtils.getLabel("message_update_latest") +
+                "  " +
+                versionOf(release).getValue() +
+                "  ";
 
         return new FutureTask<>(() -> {
             Parent root = BundleUtils.getFXMLLoader("update_dialog").load();


### PR DESCRIPTION
When there's a new Launcher release out, I get a Null Pointer Exception that crashes the launcher.

This fixes the immediate crash.

(Tagging #539 as related, but it needs more than just this one NPE check.)