### PR TITLE
fix: Remove Java 8 JVM arguments from settings

### DIFF
--- a/src/main/java/org/terasology/launcher/config/ConfigValidator.java
+++ b/src/main/java/org/terasology/launcher/config/ConfigValidator.java
@@ -49,6 +49,7 @@ class ConfigValidator {
                 .gameConfig(gameConfig.rebuilder()
                         .maxMemory(validateMaxMemory(gameConfig))
                         .initMemory(validateInitMemory(gameConfig))
+                        .javaParam(validateJavaParam(gameConfig))
                         .build())
                 .build();
     }
@@ -91,5 +92,17 @@ class ConfigValidator {
             logger.debug("Continuing with init memory: {}", valid);
         }
         return valid;
+    }
+
+    private String validateJavaParam(final GameConfig gameConfig) {
+        String params = gameConfig.getJavaParam();
+
+        final String[] deprecatedParams = {"-XX:+UseParNewGC", "-XX:+UseConcMarkSweepGC", "-XX:ParallelGCThreads=10"};
+
+        for (String deprecatedParam : deprecatedParams) {
+            params = params.replaceAll(deprecatedParam, "");
+        }
+
+        return params;
     }
 }

--- a/src/main/java/org/terasology/launcher/settings/LauncherSettingsValidator.java
+++ b/src/main/java/org/terasology/launcher/settings/LauncherSettingsValidator.java
@@ -16,6 +16,7 @@
 
 package org.terasology.launcher.settings;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,16 +33,12 @@ public final class LauncherSettingsValidator {
     private static final Logger logger = LoggerFactory.getLogger(LauncherSettingsValidator.class);
 
     private static Set<String> deprecatedParameters =
-            Sets.newHashSet("-XX:\\+UseParNewGC", "-XX:\\+UseConcMarkSweepGC", "-XX:ParallelGCThreads=10");
+            Sets.newHashSet("-XX:+UseParNewGC", "-XX:+UseConcMarkSweepGC", "-XX:ParallelGCThreads=10");
 
-    private static String removeUnsupportedJvmParameters(final String currentParams) {
-        String params = currentParams;
-
-        for (String deprecatedParam : deprecatedParameters) {
-            params = params.replaceAll(deprecatedParam, "");
-        }
-
-        return params;
+    private static String removeUnsupportedJvmParameters(final List<String> params) {
+        List<String> correctedParams = Lists.newArrayList(params);
+        correctedParams.removeAll(deprecatedParameters);
+        return String.join(" ", correctedParams);
     }
 
     private static final List<SettingsValidationRule> RULES = Arrays.asList(
@@ -62,7 +59,7 @@ public final class LauncherSettingsValidator {
             new SettingsValidationRule(
                     s -> s.getUserGameParameterList().stream().anyMatch(deprecatedParameters::contains),
                     "Ensure unsupported JVM arguments are removed",
-                    s -> s.setUserJavaParameters(removeUnsupportedJvmParameters(s.getUserJavaParameters()))
+                    s -> s.setUserJavaParameters(removeUnsupportedJvmParameters(s.getUserJavaParameterList()))
             )
     );
 

--- a/src/main/java/org/terasology/launcher/settings/LauncherSettingsValidator.java
+++ b/src/main/java/org/terasology/launcher/settings/LauncherSettingsValidator.java
@@ -16,12 +16,14 @@
 
 package org.terasology.launcher.settings;
 
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.launcher.util.JavaHeapSize;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Provides methods to check launcher settings and correct if invalid.
@@ -29,12 +31,13 @@ import java.util.List;
 public final class LauncherSettingsValidator {
     private static final Logger logger = LoggerFactory.getLogger(LauncherSettingsValidator.class);
 
+    private static Set<String> deprecatedParameters =
+            Sets.newHashSet("-XX:\\+UseParNewGC", "-XX:\\+UseConcMarkSweepGC", "-XX:ParallelGCThreads=10");
+
     private static String removeUnsupportedJvmParameters(final String currentParams) {
         String params = currentParams;
 
-        final String[] deprecatedParams = {"-XX:\\+UseParNewGC", "-XX:\\+UseConcMarkSweepGC", "-XX:ParallelGCThreads=10"};
-
-        for (String deprecatedParam : deprecatedParams) {
+        for (String deprecatedParam : deprecatedParameters) {
             params = params.replaceAll(deprecatedParam, "");
         }
 
@@ -57,7 +60,7 @@ public final class LauncherSettingsValidator {
             ),
 
             new SettingsValidationRule(
-                    s -> s.getUserJavaParameters().isEmpty(),
+                    s -> s.getUserGameParameterList().stream().anyMatch(deprecatedParameters::contains),
                     "Ensure unsupported JVM arguments are removed",
                     s -> s.setUserJavaParameters(removeUnsupportedJvmParameters(s.getUserJavaParameters()))
             )

--- a/src/main/java/org/terasology/launcher/settings/LauncherSettingsValidator.java
+++ b/src/main/java/org/terasology/launcher/settings/LauncherSettingsValidator.java
@@ -29,19 +29,37 @@ import java.util.List;
 public final class LauncherSettingsValidator {
     private static final Logger logger = LoggerFactory.getLogger(LauncherSettingsValidator.class);
 
+    private static String removeUnsupportedJvmParameters(final String currentParams) {
+        String params = currentParams;
+
+        final String[] deprecatedParams = {"-XX:\\+UseParNewGC", "-XX:\\+UseConcMarkSweepGC", "-XX:ParallelGCThreads=10"};
+
+        for (String deprecatedParam : deprecatedParams) {
+            params = params.replaceAll(deprecatedParam, "");
+        }
+
+        return params;
+    }
+
     private static final List<SettingsValidationRule> RULES = Arrays.asList(
             // Rule for max heap size
             new SettingsValidationRule(
-                s -> !(System.getProperty("os.arch").equals("x86") && s.getMaxHeapSize().compareTo(JavaHeapSize.GB_1_5) > 0),
-                "Max heap size cannot be greater than 1.5 GB for a 32-bit JVM",
-                s -> s.setMaxHeapSize(JavaHeapSize.GB_1_5)
+                    s -> !(System.getProperty("os.arch").equals("x86") && s.getMaxHeapSize().compareTo(JavaHeapSize.GB_1_5) > 0),
+                    "Max heap size cannot be greater than 1.5 GB for a 32-bit JVM",
+                    s -> s.setMaxHeapSize(JavaHeapSize.GB_1_5)
             ),
 
             // Rule for initial heap size
             new SettingsValidationRule(
-                s -> s.getInitialHeapSize().compareTo(s.getMaxHeapSize()) < 0,
+                    s -> s.getInitialHeapSize().compareTo(s.getMaxHeapSize()) < 0,
                     "Initial heap size cannot be greater than max heap size",
-                s -> s.setInitialHeapSize(s.getMaxHeapSize())
+                    s -> s.setInitialHeapSize(s.getMaxHeapSize())
+            ),
+
+            new SettingsValidationRule(
+                    s -> s.getUserJavaParameters().isEmpty(),
+                    "Ensure unsupported JVM arguments are removed",
+                    s -> s.setUserJavaParameters(removeUnsupportedJvmParameters(s.getUserJavaParameters()))
             )
     );
 


### PR DESCRIPTION
Get rid of these parameters if present:

![image](https://user-images.githubusercontent.com/1448874/80870949-fbcb7c80-8ca9-11ea-9353-93115c8c5159.png)
