### PR TITLE
ci: use platform-specific worker nodes

### DIFF
--- a/.github/workflows/asset-upload.yml
+++ b/.github/workflows/asset-upload.yml
@@ -4,7 +4,7 @@ on:
       - published
   push:
     branches:
-      -ci/os-specific-worker-nodees
+      - ci/os-specific-worker-nodees
 
 name: Asset Upload
 

--- a/.github/workflows/asset-upload.yml
+++ b/.github/workflows/asset-upload.yml
@@ -2,9 +2,7 @@ on:
   release:
     types:
       - published
-  push:
-    branches:
-      - ci/os-specific-worker-nodees
+  workflow_dispatch:
 
 name: Asset Upload
 

--- a/.github/workflows/asset-upload.yml
+++ b/.github/workflows/asset-upload.yml
@@ -2,6 +2,9 @@ on:
   release:
     types:
       - published
+  push:
+    branches:
+      -ci/os-specific-worker-nodees
 
 name: Asset Upload
 
@@ -30,6 +33,11 @@ jobs:
           java-package: jdk
       - name: Bundle distribution for ${{ matrix.platform }}
         run: ./gradlew -Prelease.useLastTag=true ${{ matrix.platform }}DistZip
+      - name: Upload bundle for ${{ matrix.platform }} as build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: ./build/distributions/TerasologyLauncher-${{ matrix.platform }}-${{ github.event.release.name }}.zip
+          name: TerasologyLauncher-${{ matrix.platform }}.zip
       - name: Upload bundle for ${{ matrix.platform }}
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/asset-upload.yml
+++ b/.github/workflows/asset-upload.yml
@@ -2,7 +2,6 @@ on:
   release:
     types:
       - published
-  workflow_dispatch:
 
 name: Asset Upload
 

--- a/.github/workflows/asset-upload.yml
+++ b/.github/workflows/asset-upload.yml
@@ -8,10 +8,17 @@ name: Asset Upload
 jobs:
   build:
     name: Build and upload release assets
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        platform: [linux64, mac, windows32, windows64]
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        include:
+          - os: ubunutu-latest
+            platform: linux64
+          - os: windows-latest
+            platform: windows64
+          - os: macos-latest
+            platform: mac
       fail-fast: true
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This is an attempt to fix #581 and #582 by building the launcher bundles on platform-specific worker nodes.
