### PR TITLE
fix: remove doubled files when bundling the JRE

### DIFF
--- a/config/gradle/jre.gradle
+++ b/config/gradle/jre.gradle
@@ -70,8 +70,6 @@ def createJreTasks(String taskNameBase,
         }
         into unpackDir
 
-        outputs.dir unpackDir
-
         dependsOn "download${taskNameBase}"
     }
 


### PR DESCRIPTION
The culprit was that `outputs.dir unpackDir` _adds_ another output directory to some list that already exists internally. This is unnecessary and, in fact, puts a duplicate into the list of outputs (note: not a set!).