### PR TITLE
Remove unnecessary access modifiers on JUnit5 tests

### DIFF
--- a/src/test/java/org/terasology/launcher/settings/TestLauncherSettings.java
+++ b/src/test/java/org/terasology/launcher/settings/TestLauncherSettings.java
@@ -43,7 +43,7 @@ import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_SEA
 import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_USER_GAME_PARAMETERS;
 import static org.terasology.launcher.settings.BaseLauncherSettings.PROPERTY_USER_JAVA_PARAMETERS;
 
-public class TestLauncherSettings {
+class TestLauncherSettings {
     @TempDir
     Path tempDirectory;
     @TempDir
@@ -79,14 +79,14 @@ public class TestLauncherSettings {
     }
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() {
         testPropertiesFile = tempDirectory.resolve(BaseLauncherSettings.LAUNCHER_SETTINGS_FILE_NAME);
 
         baseLauncherSettings = Settings.getDefault();
     }
 
     @Test
-    public void testInitWithValues() throws Exception {
+    void testInitWithValues() throws Exception {
         //initialise properties with sample values
         locale = "en";
         maxHeapSize = "GB_2_5";
@@ -123,7 +123,7 @@ public class TestLauncherSettings {
     }
 
     @Test
-    public void testInitDefault() throws Exception {
+    void testInitDefault() throws Exception {
         //null properties file
 
         baseLauncherSettings = Settings.getDefault();
@@ -143,7 +143,7 @@ public class TestLauncherSettings {
     }
 
     @Test
-    public void testSetters() throws Exception {
+    void testSetters() throws Exception {
         //re-initialise properties with sample values
         locale = "fr";
         maxHeapSize = "GB_4";

--- a/src/test/java/org/terasology/launcher/util/TestFileUtils.java
+++ b/src/test/java/org/terasology/launcher/util/TestFileUtils.java
@@ -47,14 +47,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestFileUtils {
+class TestFileUtils {
 
     private static final String FILE_NAME = "File";
     private static final String DIRECTORY_NAME = "lorem";
     private static final String SAMPLE_TEXT = "Lorem Ipsum";
 
     @TempDir
-    public Path tempFolder;
+    Path tempFolder;
     boolean isPosix;
 
     @BeforeEach
@@ -63,7 +63,7 @@ public class TestFileUtils {
     }
 
     @Test
-    public void testCannotCreateDirectory() throws IOException {
+    void testCannotCreateDirectory() throws IOException {
         final Path directory = tempFolder.resolve(DIRECTORY_NAME);
         var tempFolderFile = tempFolder.toFile();
 
@@ -95,7 +95,7 @@ public class TestFileUtils {
     }
 
     @Test
-    public void testNotDirectory() throws IOException {
+    void testNotDirectory() throws IOException {
         var notDirectory = tempFolder.resolve("notADirectory");
         Files.createFile(notDirectory);
 
@@ -106,7 +106,7 @@ public class TestFileUtils {
     }
 
     @Test
-    public void testNoPerms() throws IOException {
+    void testNoPerms() throws IOException {
         var directory = tempFolder.resolve(DIRECTORY_NAME);
         Files.createDirectory(directory);
         var d = directory.toFile();
@@ -142,7 +142,7 @@ public class TestFileUtils {
     }
 
     @Test
-    public void testDeleteFile() throws IOException {
+    void testDeleteFile() throws IOException {
         Path directory = tempFolder;
         Path file = directory.resolve(FILE_NAME);
         Files.createFile(file);
@@ -153,7 +153,7 @@ public class TestFileUtils {
     }
 
     @Test
-    public void testDeleteDirectoryContent() throws IOException {
+    void testDeleteDirectoryContent() throws IOException {
         Path directory = tempFolder;
         Path file = directory.resolve(FILE_NAME);
         Files.createFile(file);
@@ -167,7 +167,7 @@ public class TestFileUtils {
      * Test that `FileUtils.ensureEmptyDir` creates and empty directory if it does not exist.
      */
     @Test
-    public void testEnsureEmptyDirCreation() throws IOException {
+    void testEnsureEmptyDirCreation() throws IOException {
         Path context = tempFolder;
         // setup
         Path dirToTest = context.resolve(DIRECTORY_NAME);
@@ -183,7 +183,7 @@ public class TestFileUtils {
      * Test that `FileUtils.ensureEmptyDir` drains (delete all content) if the directory exists.
      */
     @Test
-    public void testEnsureEmptyDirDrain() throws IOException {
+    void testEnsureEmptyDirDrain() throws IOException {
         Path context = tempFolder;
         // setup
         Path dirToTest = context.resolve(DIRECTORY_NAME);
@@ -201,7 +201,7 @@ public class TestFileUtils {
     }
 
     @Test
-    public void testCopyFolder(@TempDir Path source, @TempDir Path destination) throws IOException {
+    void testCopyFolder(@TempDir Path source, @TempDir Path destination) throws IOException {
         Path fileInSource = source.resolve(FILE_NAME);
         Files.createFile(fileInSource);
         assertTrue(Files.exists(fileInSource));
@@ -217,7 +217,7 @@ public class TestFileUtils {
     }
 
     @Test
-    public void testDeleteFileSilently() throws IOException {
+    void testDeleteFileSilently() throws IOException {
         Path tempFile = tempFolder.resolve(FILE_NAME);
         Files.createFile(tempFile);
         assertTrue(Files.exists(tempFile));
@@ -227,7 +227,7 @@ public class TestFileUtils {
     }
 
     @Test
-    public void testDeleteFileSilentlyWithEmptyDirectory() {
+    void testDeleteFileSilentlyWithEmptyDirectory() {
         assertTrue(Files.exists(tempFolder));
 
         FileUtils.deleteFileSilently(tempFolder);
@@ -235,7 +235,7 @@ public class TestFileUtils {
     }
 
     @Test
-    public void testDeleteFileSilentlyWithNonEmptyDirectory() throws IOException {
+    void testDeleteFileSilentlyWithNonEmptyDirectory() throws IOException {
         Path tempFile = tempFolder.resolve(FILE_NAME);
         Files.createFile(tempFile);
         assertTrue(Files.exists(tempFile));
@@ -252,7 +252,7 @@ public class TestFileUtils {
     }
 
     @Test
-    public void testExtract(@TempDir Path zipDir, @TempDir Path outputDir) throws IOException {
+    void testExtract(@TempDir Path zipDir, @TempDir Path outputDir) throws IOException {
         final String fileInRoot = "fileInRoot";
         final String fileInFolder = "folder/fileInFolder";
         final String file1Contents = SAMPLE_TEXT + "1";

--- a/src/test/java/org/terasology/launcher/util/TestLanguages.java
+++ b/src/test/java/org/terasology/launcher/util/TestLanguages.java
@@ -24,99 +24,99 @@ import java.util.Locale;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public final class TestLanguages {
+final class TestLanguages {
 
-    public TestLanguages() {
+    TestLanguages() {
     }
 
     @Test
-    public void testDefaultLanguage() {
+    void testDefaultLanguage() {
         assertEquals(Locale.ENGLISH, Languages.DEFAULT_LOCALE);
     }
 
     @Test
-    public void testUpdateWithDefault() {
+    void testUpdateWithDefault() {
         Languages.update(Languages.DEFAULT_LOCALE);
         assertSame(Languages.DEFAULT_LOCALE, Languages.getCurrentLocale());
     }
 
     @Test
-    public void testUpdateWithEnglish() {
+    void testUpdateWithEnglish() {
         Languages.update(Locale.ENGLISH);
         assertSame(Locale.ENGLISH, Languages.getCurrentLocale());
     }
 
     @Test
-    public void testUpdateWithGerman() {
+    void testUpdateWithGerman() {
         Languages.update(Locale.GERMAN);
         assertSame(Locale.GERMAN, Languages.getCurrentLocale());
     }
 
     @Test
-    public void testUpdateWithGermany() {
+    void testUpdateWithGermany() {
         Languages.update(Languages.DEFAULT_LOCALE);
         Languages.update(Locale.GERMANY);
         assertSame(Languages.DEFAULT_LOCALE, Languages.getCurrentLocale());
     }
 
     @Test
-    public void testUpdateWithJapanese() {
+    void testUpdateWithJapanese() {
         Languages.update(Locale.JAPANESE);
         assertSame(Locale.JAPANESE, Languages.getCurrentLocale());
     }
 
     @Test
-    public void testUpdateWithJapan() {
+    void testUpdateWithJapan() {
         Languages.update(Languages.DEFAULT_LOCALE);
         Languages.update(Locale.JAPAN);
         assertSame(Languages.DEFAULT_LOCALE, Languages.getCurrentLocale());
     }
 
     @Test
-    public void testInitWithDefault() {
+    void testInitWithDefault() {
         Languages.init(Languages.DEFAULT_LOCALE.toString());
         assertSame(Languages.DEFAULT_LOCALE, Languages.getCurrentLocale());
     }
 
     @Test
-    public void testInitWithEnglish() {
+    void testInitWithEnglish() {
         Languages.init(Locale.ENGLISH.toString());
         assertSame(Locale.ENGLISH, Languages.getCurrentLocale());
     }
 
     @Test
-    public void testInitWithGerman() {
+    void testInitWithGerman() {
         Languages.init(Locale.GERMAN.toString());
         assertSame(Locale.GERMAN, Languages.getCurrentLocale());
     }
 
     @Test
-    public void testInitWithGermany() {
+    void testInitWithGermany() {
         Languages.init(Languages.DEFAULT_LOCALE.toString());
         Languages.init(Locale.GERMANY.toString());
         assertSame(Languages.DEFAULT_LOCALE, Languages.getCurrentLocale());
     }
 
     @Test
-    public void testInitWithJapanese() {
+    void testInitWithJapanese() {
         Languages.init(Locale.JAPANESE.toString());
         assertSame(Locale.JAPANESE, Languages.getCurrentLocale());
     }
 
     @Test
-    public void testInitWithJapan() {
+    void testInitWithJapan() {
         Languages.init(Languages.DEFAULT_LOCALE.toString());
         Languages.init(Locale.JAPAN.toString());
         assertSame(Languages.DEFAULT_LOCALE, Languages.getCurrentLocale());
     }
 
     @Test
-    public void testSize() {
+    void testSize() {
         assertEquals(Languages.SUPPORTED_LOCALES.size(), Languages.SETTINGS_LABEL_KEYS.size());
     }
 
     @AfterAll
-    public static void resetLanguages() {
+    static void resetLanguages() {
         Languages.init(Languages.DEFAULT_LOCALE.toString());
     }
 }

--- a/src/test/java/org/terasology/launcher/util/TestLauncherDirectoryUtils.java
+++ b/src/test/java/org/terasology/launcher/util/TestLauncherDirectoryUtils.java
@@ -29,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.terasology.launcher.util.LauncherDirectoryUtils.containsFiles;
 import static org.terasology.launcher.util.LauncherDirectoryUtils.containsGameData;
 
-public class TestLauncherDirectoryUtils {
+class TestLauncherDirectoryUtils {
 
     @TempDir
-    public Path tempFolder;
+    Path tempFolder;
 
     @Test
-    public void testDirectoryWithFiles() throws IOException {
+    void testDirectoryWithFiles() throws IOException {
         Path file = tempFolder.resolve("File");
         assertNotNull(Files.createFile(file));
         assertTrue(containsFiles(tempFolder));
     }
 
     @Test
-    public void testEmptyDirectory() throws IOException {
+    void testEmptyDirectory() throws IOException {
         assertFalse(containsFiles(tempFolder));
     }
 
     @Test
-    public void testGameDirectory() throws IOException {
+    void testGameDirectory() throws IOException {
         Path savesDirectory = tempFolder.resolve(GameDataDirectoryNames.SAVES.getName());
         Path saveFile = savesDirectory.resolve("saveFile");
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for TerasologyLauncher! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Removes no longer necessary `public` access modifiers from JUnit5 tests as it's no longer necessary to have them.
See https://junit.org/junit5/docs/current/user-guide/#writing-tests-classes-and-methods for more details.

### How to test

- clone
- run `./gradlew test` - all test should still pass

### Outstanding before merging

I didn't touch the `TestGameRunner` tests, as it is using `Spf4jTestLogJUnitRunner` which is based on JUnit4 and there is still required to have the modifiers present. If anybody has an idea of how to approach these tests in JUnit5, I'm all ears :)