### PR TITLE
chore: remove deprecations on LauncherConfig and LauncherSettings

### DIFF
--- a/src/main/java/org/terasology/launcher/LauncherConfiguration.java
+++ b/src/main/java/org/terasology/launcher/LauncherConfiguration.java
@@ -29,10 +29,7 @@ import java.nio.file.Path;
  *  - directories managed by the launcher
  *  - user settings in form of {@link BaseLauncherSettings}
  *  - the {@link PackageManager} used to download new games
- *
- * @deprecated use {@link org.terasology.launcher.config.Config} instead
  */
-@Deprecated
 public class LauncherConfiguration {
 
     private final Path launcherDirectory;

--- a/src/main/java/org/terasology/launcher/NullLauncherConfiguration.java
+++ b/src/main/java/org/terasology/launcher/NullLauncherConfiguration.java
@@ -22,7 +22,6 @@ package org.terasology.launcher;
  * For instance, the launcher self update process stops the configuration assemble process. Instead of returning <code>null</code> the
  * NullLauncherConfiguration can intentionally be returned.
  */
-@Deprecated
 public final class NullLauncherConfiguration extends LauncherConfiguration {
 
     private static NullLauncherConfiguration instance;

--- a/src/main/java/org/terasology/launcher/settings/BaseLauncherSettings.java
+++ b/src/main/java/org/terasology/launcher/settings/BaseLauncherSettings.java
@@ -32,9 +32,7 @@ import java.util.Properties;
 /**
  * Provides access to launcher settings.
  *
- * @deprecated to be replaced by {@link org.terasology.launcher.config.Config}
  */
-@Deprecated
 public final class BaseLauncherSettings extends LauncherSettings {
 
     public static final String USER_JAVA_PARAMETERS_DEFAULT = "-XX:MaxGCPauseMillis=20";

--- a/src/main/java/org/terasology/launcher/settings/LauncherSettings.java
+++ b/src/main/java/org/terasology/launcher/settings/LauncherSettings.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2016 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.launcher.settings;
 
@@ -21,17 +8,12 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 import org.terasology.launcher.util.JavaHeapSize;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
 
-/**
- * @deprecated to be replaced by {@link org.terasology.launcher.config.Config}
- */
-@Deprecated
 public abstract class LauncherSettings {
 
     private static final Logger logger = LoggerFactory.getLogger(LauncherSettings.class);


### PR DESCRIPTION
Follow up to #603 by reverting the deprecations we put on several classes in anticipation of the adoption of `Config`. As the supposed replacement was just removed the deprecations no longer hold.