### PR TITLE
build(ci): enable check-run-reporter for push validation

### DIFF
--- a/.github/workflows/push-validation.yml
+++ b/.github/workflows/push-validation.yml
@@ -1,6 +1,9 @@
 name: Push Validation
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
   validate:
@@ -27,11 +30,25 @@ jobs:
         JAVA_TOOL_OPTIONS: -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.verbose=true
       run: ./gradlew test
     - uses: actions/upload-artifact@v2
-      #TODO: use https://www.check-run-reporter.com/ or similar instead
       if: failure()
       with:
         name: test-report
         path: build/reports/tests/test/
+    - name: Upload Test Report
+      uses: check-run-reporter/action@v2.0.0
+      # always run, otherwise you'll only see results for passing builds
+      if: always()
+      with:
+        label: test
+        token: ${{ secrets.CHECK_RUN_REPORTER_TOKEN }}
+        report: 'build/test-results/**/*.xml'
     - name: Static Code Analysis
       run: ./gradlew check -x test
-
+    - name: Upload Checkstyle Report
+      uses: check-run-reporter/action@v2.0.0
+      # always run, otherwise you'll only see results for passing builds
+      if: always()
+      with:
+        label: code-analysis
+        token: ${{ secrets.CHECK_RUN_REPORTER_TOKEN }}
+        report: 'build/reports/**/*.xml'


### PR DESCRIPTION
Enables [check-run-reporter](https://www.check-run-reporter.com) for this repository to get a better overview of failed tests and checkstyle reports. The plan for open source projects is without costs.
The reporting is by no means perfect, but maybe it helps in one or another situation. If anyone finds better tooling for this we can give that a try...

![image](https://user-images.githubusercontent.com/1448874/96855401-f67f0b80-145c-11eb-9b75-c848d248a129.png)


I've already added the `CHECK_RUN_REPORTER_TOKEN` secret in the repository settings.

This also includes a small change so that the push validation is only executed once per PR or commit to master (for PRs within the repository we run the check twice before).
