### PR TITLE
fix(tests): fix flaky TestRunGameTask tests

### DIFF
--- a/.idea/dictionaries/kevint.xml
+++ b/.idea/dictionaries/kevint.xml
@@ -4,6 +4,7 @@
       <w>bellsoft</w>
       <w>cooldown</w>
       <w>liberica</w>
+      <w>spdx</w>
       <w>terasology</w>
     </words>
   </dictionary>

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ dependencies {
     }
     testImplementation "org.mockito:mockito-junit-jupiter:3.3.+"
 
-    testImplementation('org.spf4j:spf4j-slf4j-test:8.8.+') {
+    testImplementation('org.spf4j:spf4j-slf4j-test:8.8.5') {
         because "testable logging"
     }
     testImplementation("org.slf4j:slf4j-api:1.7.+!!") {


### PR DESCRIPTION
Fixes the flaky TestRunGameTask.testSuccessEvent test referred to in #611.

I didn't exactly get a foolproof reproduction plan, but setting my JDK to Java 15 (as is used by the push-validation workflow) and having IntelliJ IDEA run the testSuccessEvent task "until failure" would trigger it within a minute.

I wasn't as successful in triggering a race condition in testFastExit, but it does use the same technique so I applied it there as well.

Instead of using properties or events, as my comment in #611 proposed, I used [Platform.runLater](https://openjfx.io/javadoc/15/javafx.graphics/javafx/application/Platform.html#runLater(java.lang.Runnable)) to queue the handler to run on the application thread.

I did spend a few minutes looking for a way to use one of the other abstractions but it didn't feel like they were going to provide a cleaner solution. e.g. I might have to wrap them in Platform.runLater anyway.

 
