### PR TITLE
chore(tests): remove extraneous waitForFxEvents calls

### DIFF
--- a/src/test/java/org/terasology/launcher/game/TestRunGameTask.java
+++ b/src/test/java/org/terasology/launcher/game/TestRunGameTask.java
@@ -114,8 +114,6 @@ public class TestRunGameTask {
 
         executor.submit(gameTask);
 
-        WaitForAsyncUtils.waitForFxEvents();
-
         gameTask.get();
 
         hasExitMessage.assertObservation(100, TimeUnit.MILLISECONDS);
@@ -136,8 +134,6 @@ public class TestRunGameTask {
 
         executor.submit(gameTask);
 
-        WaitForAsyncUtils.waitForFxEvents();
-
         var thrown = assertThrows(ExecutionException.class, gameTask::get);
         Throwable exc = thrown.getCause();
         assertThat(exc, instanceOf(RunGameTask.GameExitError.class));
@@ -152,8 +148,6 @@ public class TestRunGameTask {
 
         executor.submit(gameTask);
 
-        WaitForAsyncUtils.waitForFxEvents();
-
         var thrown = assertThrows(ExecutionException.class, gameTask::get);
         Throwable exc = thrown.getCause();
         assertThat(exc, instanceOf(RunGameTask.GameStartError.class));
@@ -166,8 +160,6 @@ public class TestRunGameTask {
         var gameTask = new RunGameTask(UnixProcesses.NO_SUCH_COMMAND);
 
         executor.submit(gameTask);
-
-        WaitForAsyncUtils.waitForFxEvents();
 
         var thrown = assertThrows(ExecutionException.class, gameTask::get);
         Throwable exc = thrown.getCause();
@@ -186,8 +178,6 @@ public class TestRunGameTask {
         var gameTask = new RunGameTask(new UnixProcesses.SelfDestructingProcess(5));
 
         executor.submit(gameTask);
-
-        WaitForAsyncUtils.waitForFxEvents();
 
         var thrown = assertThrows(ExecutionException.class, gameTask::get);
         Throwable exc = thrown.getCause();


### PR DESCRIPTION
@skaldarnar, I found `waitForFxEvents` in more places than I expected. Were these tests observed to fail with race conditions too, or did we get extras as a “better safe than sorry” sort of thing?

I don't expect these tests to have the same type of race condition as `testSuccessEvent` did, as they don't do the same sort of building-a-list-from-multiple-threads thing and they don't add any event handlers.

Let me know if we have build results somewhere showing that they _do_ fail; that would point us toward some other cause I overlooked.