### PR TITLE
fix(repositories): make JenkinsRepositoryAdapter more resilient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,12 +111,12 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.+"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.6.+"
 
-    testImplementation('org.mockito:mockito-inline:3.3.+') {
+    testImplementation('org.mockito:mockito-inline:3.4.+') {
         because "-inline build enables mocking final classes"
         // https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.2
         // > Be aware that this artifact may be abolished when the inline mock making feature is integrated into the default mock maker.
     }
-    testImplementation "org.mockito:mockito-junit-jupiter:3.3.+"
+    testImplementation "org.mockito:mockito-junit-jupiter:3.4.+"
 
     testImplementation('org.spf4j:spf4j-slf4j-test:8.8.5') {
         because "testable logging"

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ dependencies {
 
     testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.+"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.6.+"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.6.+"
 
     testImplementation('org.mockito:mockito-inline:3.4.+') {

--- a/src/main/java/org/terasology/launcher/repositories/Jenkins.java
+++ b/src/main/java/org/terasology/launcher/repositories/Jenkins.java
@@ -9,16 +9,13 @@ package org.terasology.launcher.repositories;
 public final class Jenkins {
 
     private Jenkins() {
-
     }
 
     public static class ApiResult {
         public Build[] builds;
-        public Project[] upstreamProjects;
     }
 
     public static class Build {
-        public Action[] actions;
         public String number;
         public Result result;
         public Artifact[] artifacts;
@@ -42,18 +39,5 @@ public final class Jenkins {
 
     public static class Change {
         public String msg;
-    }
-
-    public static class Action {
-        public Cause[] causes;
-    }
-
-    public static class Cause {
-        public String upstreamProject;
-        public String upstreamBuild;
-    }
-
-    public static class Project {
-        public String name;
     }
 }

--- a/src/main/java/org/terasology/launcher/repositories/JenkinsClient.java
+++ b/src/main/java/org/terasology/launcher/repositories/JenkinsClient.java
@@ -1,0 +1,47 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.launcher.repositories;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.Properties;
+
+public class JenkinsClient {
+
+    private final Gson gson;
+
+    public JenkinsClient(Gson gson) {
+        this.gson = gson;
+    }
+
+    public Jenkins.ApiResult request(URL url) {
+        Preconditions.checkNotNull(url);
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
+            return gson.fromJson(reader, Jenkins.ApiResult.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @Nullable
+    Properties requestProperties(final URL artifactUrl) {
+        Preconditions.checkNotNull(artifactUrl);
+        try (InputStream inputStream = artifactUrl.openStream()) {
+            final Properties properties = new Properties();
+            properties.load(inputStream);
+            return properties;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapter.java
+++ b/src/main/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapter.java
@@ -78,7 +78,7 @@ class JenkinsRepositoryAdapter implements ReleaseRepository {
     }
 
     private Optional<GameRelease> computeReleaseFrom(Jenkins.Build jenkinsBuildInfo) {
-        if (isSuccess(jenkinsBuildInfo)) {
+        if (hasAcceptableResult(jenkinsBuildInfo)) {
             final URL url = getArtifactUrl(jenkinsBuildInfo, TERASOLOGY_ZIP_PATTERN);
             final Date timestamp = new Date(jenkinsBuildInfo.timestamp);
             final List<String> changelog = computeChangelogFrom(jenkinsBuildInfo);
@@ -152,7 +152,7 @@ class JenkinsRepositoryAdapter implements ReleaseRepository {
 
     // generic Jenkins.Build utility
 
-    private static boolean isSuccess(Jenkins.Build build) {
+    private static boolean hasAcceptableResult(Jenkins.Build build) {
         return build.result == Jenkins.Build.Result.SUCCESS || build.result == Jenkins.Build.Result.UNSTABLE;
     }
 

--- a/src/main/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapter.java
+++ b/src/main/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapter.java
@@ -4,6 +4,7 @@
 package org.terasology.launcher.repositories;
 
 import com.google.gson.Gson;
+
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,14 +54,15 @@ class JenkinsRepositoryAdapter implements ReleaseRepository {
     private static final String TERASOLOGY_ZIP_PATTERN = "Terasology.*zip";
     private static final String ARTIFACT = "artifact/";
 
-    private final Gson gson = new Gson();
+    private final Gson gson;
 
     private final Build buildProfile;
     private final Profile profile;
 
     private final URL apiUrl;
 
-    JenkinsRepositoryAdapter(Profile profile, Build buildProfile) {
+    JenkinsRepositoryAdapter(Profile profile, Build buildProfile, Gson gson) {
+        this.gson = gson;
         this.buildProfile = buildProfile;
         this.profile = profile;
         this.apiUrl = toURL(BASE_URL + job(profileToJobName(profile)) + job(buildProfileToJobName(buildProfile)) + API_FILTER);
@@ -68,8 +70,6 @@ class JenkinsRepositoryAdapter implements ReleaseRepository {
 
     public List<GameRelease> fetchReleases() {
         final List<GameRelease> pkgList = new LinkedList<>();
-
-
 
         logger.debug("fetching releases from '{}'", apiUrl);
 

--- a/src/main/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapter.java
+++ b/src/main/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapter.java
@@ -78,7 +78,7 @@ class JenkinsRepositoryAdapter implements ReleaseRepository {
         return pkgList;
     }
 
-    Optional<GameRelease> computeReleaseFrom(Jenkins.Build jenkinsBuildInfo) {
+    private Optional<GameRelease> computeReleaseFrom(Jenkins.Build jenkinsBuildInfo) {
         if (isSuccess(jenkinsBuildInfo)) {
             final URL url = getArtifactUrl(jenkinsBuildInfo, TERASOLOGY_ZIP_PATTERN);
             final Date timestamp = new Date(jenkinsBuildInfo.timestamp);
@@ -96,7 +96,7 @@ class JenkinsRepositoryAdapter implements ReleaseRepository {
         return Optional.empty();
     }
 
-    Optional<GameIdentifier> computeIdentifierFrom(Jenkins.Build jenkinsBuildInfo) {
+    private Optional<GameIdentifier> computeIdentifierFrom(Jenkins.Build jenkinsBuildInfo) {
         Properties versionInfo = client.requestProperties(getArtifactUrl(jenkinsBuildInfo, "versionInfo.properties"));
         if (versionInfo != null && versionInfo.containsKey("displayVersion")) {
             String displayName = versionInfo.getProperty("displayVersion");
@@ -105,7 +105,7 @@ class JenkinsRepositoryAdapter implements ReleaseRepository {
         return Optional.empty();
     }
 
-    List<String> computeChangelogFrom(Jenkins.Build jenkinsBuildInfo) {
+    private List<String> computeChangelogFrom(Jenkins.Build jenkinsBuildInfo) {
         return Optional.ofNullable(jenkinsBuildInfo.changeSet)
                 .map(changeSet ->
                         Arrays.stream(changeSet.items)
@@ -161,6 +161,9 @@ class JenkinsRepositoryAdapter implements ReleaseRepository {
 
     @Nullable
     private URL getArtifactUrl(Jenkins.Build build, String regex) {
+        if (build.artifacts == null || build.url == null) {
+            return null;
+        }
         Optional<String> url = Arrays.stream(build.artifacts)
                 .filter(artifact -> artifact.fileName.matches(regex))
                 .findFirst()

--- a/src/main/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapter.java
+++ b/src/main/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapter.java
@@ -19,7 +19,6 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.stream.Collectors;
 
 /**
@@ -97,12 +96,10 @@ class JenkinsRepositoryAdapter implements ReleaseRepository {
     }
 
     private Optional<GameIdentifier> computeIdentifierFrom(Jenkins.Build jenkinsBuildInfo) {
-        Properties versionInfo = client.requestProperties(getArtifactUrl(jenkinsBuildInfo, "versionInfo.properties"));
-        if (versionInfo != null && versionInfo.containsKey("displayVersion")) {
-            String displayName = versionInfo.getProperty("displayVersion");
-            return Optional.of(new GameIdentifier(displayName, buildProfile, profile));
-        }
-        return Optional.empty();
+        return Optional.ofNullable(getArtifactUrl(jenkinsBuildInfo, "versionInfo.properties"))
+                .map(client::requestProperties)
+                .map(versionInfo -> versionInfo.getProperty("displayVersion"))
+                .map(displayVersion -> new GameIdentifier(displayVersion, buildProfile, profile));
     }
 
     private List<String> computeChangelogFrom(Jenkins.Build jenkinsBuildInfo) {

--- a/src/main/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapter.java
+++ b/src/main/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapter.java
@@ -75,9 +75,14 @@ class JenkinsRepositoryAdapter implements ReleaseRepository {
 
         try (BufferedReader reader = openConnection()) {
             final Jenkins.ApiResult result = gson.fromJson(reader, Jenkins.ApiResult.class);
-            for (Jenkins.Build build : result.builds) {
-                computeReleaseFrom(build).ifPresent(pkgList::add);
+            if (result != null && result.builds != null) {
+                for (Jenkins.Build build : result.builds) {
+                    computeReleaseFrom(build).ifPresent(pkgList::add);
+                }
+            } else {
+                logger.debug("No build information.");
             }
+            
         } catch (IOException e) {
             logger.warn("Failed to fetch packages from: {}", apiUrl, e);
         }

--- a/src/main/java/org/terasology/launcher/repositories/RepositoryManager.java
+++ b/src/main/java/org/terasology/launcher/repositories/RepositoryManager.java
@@ -5,7 +5,6 @@ package org.terasology.launcher.repositories;
 
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
-
 import org.terasology.launcher.model.Build;
 import org.terasology.launcher.model.GameRelease;
 import org.terasology.launcher.model.Profile;
@@ -25,10 +24,9 @@ public class RepositoryManager {
         ReleaseRepository legacyOmegaNightly = new LegacyJenkinsRepositoryAdapter(JENKINS_BASE_URL, "DistroOmega", Build.NIGHTLY, Profile.OMEGA);
         ReleaseRepository legacyOmegaStable = new LegacyJenkinsRepositoryAdapter(JENKINS_BASE_URL, "DistroOmegaRelease", Build.STABLE, Profile.OMEGA);
 
-        Gson gson = new Gson();
-
-        ReleaseRepository omegaNightly = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.NIGHTLY, gson);
-        ReleaseRepository omegaStable = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.STABLE, gson);
+        JenkinsClient client = new JenkinsClient(new Gson());
+        ReleaseRepository omegaNightly = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.NIGHTLY, client);
+        ReleaseRepository omegaStable = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.STABLE, client);
 
         Set<ReleaseRepository> all = Sets.newHashSet(
                 legacyEngineNightly, legacyEngineStable,

--- a/src/main/java/org/terasology/launcher/repositories/RepositoryManager.java
+++ b/src/main/java/org/terasology/launcher/repositories/RepositoryManager.java
@@ -4,6 +4,8 @@
 package org.terasology.launcher.repositories;
 
 import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+
 import org.terasology.launcher.model.Build;
 import org.terasology.launcher.model.GameRelease;
 import org.terasology.launcher.model.Profile;
@@ -23,8 +25,10 @@ public class RepositoryManager {
         ReleaseRepository legacyOmegaNightly = new LegacyJenkinsRepositoryAdapter(JENKINS_BASE_URL, "DistroOmega", Build.NIGHTLY, Profile.OMEGA);
         ReleaseRepository legacyOmegaStable = new LegacyJenkinsRepositoryAdapter(JENKINS_BASE_URL, "DistroOmegaRelease", Build.STABLE, Profile.OMEGA);
 
-        ReleaseRepository omegaNightly = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.NIGHTLY);
-        ReleaseRepository omegaStable = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.STABLE);
+        Gson gson = new Gson();
+
+        ReleaseRepository omegaNightly = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.NIGHTLY, gson);
+        ReleaseRepository omegaStable = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.STABLE, gson);
 
         Set<ReleaseRepository> all = Sets.newHashSet(
                 legacyEngineNightly, legacyEngineStable,

--- a/src/test/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapterTest.java
+++ b/src/test/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapterTest.java
@@ -1,0 +1,38 @@
+package org.terasology.launcher.repositories;
+
+import static org.mockito.Mockito.when;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+
+import com.google.gson.Gson;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.terasology.launcher.model.Build;
+import org.terasology.launcher.model.Profile;
+
+public class JenkinsRepositoryAdapterTest {
+
+  @Test
+  void fetchReleases_ioExceptionOnApi() throws IOException {
+    final JenkinsRepositoryAdapter adapter = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.STABLE, new Gson());
+    final JenkinsRepositoryAdapter stub = Mockito.spy(adapter);
+    Mockito.when(stub.openConnection()).thenThrow(IOException.class);
+
+    Assertions.assertTrue(adapter.fetchReleases().isEmpty());  
+  }
+
+  @Test
+  void fetchReleases_emptyResponse() throws IOException {
+    BufferedReader stubReader = Mockito.mock(BufferedReader.class);
+    when(stubReader.readLine()).thenReturn("");
+
+    final JenkinsRepositoryAdapter adapter = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.STABLE, new Gson());
+    final JenkinsRepositoryAdapter stub = Mockito.spy(adapter);
+    Mockito.when(stub.openConnection()).thenReturn(stubReader);
+
+    Assertions.assertTrue(adapter.fetchReleases().isEmpty());  
+  }
+}

--- a/src/test/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapterTest.java
+++ b/src/test/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapterTest.java
@@ -4,13 +4,16 @@ import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.Optional;
 
+import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.terasology.launcher.model.Build;
+import org.terasology.launcher.model.GameRelease;
 import org.terasology.launcher.model.Profile;
 
 public class JenkinsRepositoryAdapterTest {
@@ -49,5 +52,43 @@ public class JenkinsRepositoryAdapterTest {
     Mockito.when(stub.openConnection()).thenReturn(stubReader);
 
     Assertions.assertTrue(adapter.fetchReleases().isEmpty());  
+  }
+
+  @Test
+  void fetchReleases_assumeInvalidRelease() throws IOException {
+    Jenkins.Build buildStub = new Jenkins.Build();
+    Jenkins.ApiResult resultStub = new Jenkins.ApiResult();
+    resultStub.builds = new Jenkins.Build[]{buildStub};
+
+    Gson gsonStub = Mockito.mock(Gson.class);
+    Mockito.doReturn(resultStub).when(gsonStub).fromJson(Mockito.any(BufferedReader.class), Mockito.eq(Jenkins.ApiResult.class));
+
+    final JenkinsRepositoryAdapter adapter = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.STABLE, gsonStub);
+    final JenkinsRepositoryAdapter spy = Mockito.spy(adapter);
+
+    Mockito.doReturn(Optional.empty()).when(spy).computeReleaseFrom(buildStub);
+
+    Assertions.assertTrue(spy.fetchReleases().isEmpty());
+    // behavior to ensure that we are testing the correct code path
+    Mockito.verify(spy).computeReleaseFrom(buildStub);
+  }
+
+  @Test
+  void fetchReleases_assumeValidRelease() throws IOException {
+    final GameRelease expected = new GameRelease(null, null, null, null);
+
+    Jenkins.Build buildStub = new Jenkins.Build();
+    Jenkins.ApiResult resultStub = new Jenkins.ApiResult();
+    resultStub.builds = new Jenkins.Build[]{buildStub};
+
+    Gson gsonStub = Mockito.mock(Gson.class);
+    Mockito.doReturn(resultStub).when(gsonStub).fromJson(Mockito.any(BufferedReader.class), Mockito.eq(Jenkins.ApiResult.class));
+
+    final JenkinsRepositoryAdapter adapter = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.STABLE, gsonStub);
+    final JenkinsRepositoryAdapter spy = Mockito.spy(adapter);
+
+    Mockito.doReturn(Optional.of(expected)).when(spy).computeReleaseFrom(buildStub);
+
+    Assertions.assertIterableEquals(Lists.newArrayList(expected), spy.fetchReleases());
   }
 }

--- a/src/test/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapterTest.java
+++ b/src/test/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapterTest.java
@@ -45,7 +45,8 @@ class JenkinsRepositoryAdapterTest {
         incompleteResults = incompletePayloads().stream()
                 .map(json -> gson.fromJson(json, Jenkins.ApiResult.class))
                 .collect(Collectors.toList());
-        expectedArtifactUrl = new URL("http://jenkins.terasology.io/teraorg/job/Nanoware/job/Omega/job/develop/1/artifact/distros/omega/build/distributions/TerasologyOmega.zip");
+        expectedArtifactUrl = new URL("http://jenkins.terasology.io/teraorg/job/Nanoware/job/Omega/job/develop/1/"
+                + "artifact/" + "distros/omega/build/distributions/TerasologyOmega.zip");
     }
 
     static String validPayload() {
@@ -131,7 +132,7 @@ class JenkinsRepositoryAdapterTest {
 
     @Test
     @DisplayName("handle null Jenkins response gracefully")
-    void shouldHandleNullJenkinsResponseGracefully() {
+    void handleNullJenkinsResponseGracefully() {
         final JenkinsClient nullClient = new StubJenkinsClient(url -> null, url -> null);
         final JenkinsRepositoryAdapter adapter = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.STABLE, nullClient);
         assertTrue(adapter.fetchReleases().isEmpty());
@@ -139,7 +140,7 @@ class JenkinsRepositoryAdapterTest {
 
     @Test
     @DisplayName("skip builds without version info")
-    void shouldSkipBuildsWithoutVersionInfo() {
+    void skipBuildsWithoutVersionInfo() {
         Properties emptyVersionInfo = new Properties();
 
         final JenkinsClient stubClient = new StubJenkinsClient(url -> validResult, url -> emptyVersionInfo);
@@ -151,7 +152,7 @@ class JenkinsRepositoryAdapterTest {
 
     @Test
     @DisplayName("process valid response correctly")
-    void shouldProcessValidResponseCorrectly() {
+    void processValidResponseCorrectly() {
         String expectedVersion = "alpha 42 (preview) - 20210130";
 
         Properties versionInfo = new Properties();
@@ -164,8 +165,8 @@ class JenkinsRepositoryAdapterTest {
 
         final JenkinsRepositoryAdapter adapter = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.STABLE, stubClient);
 
+        assertEquals(1, adapter.fetchReleases().size());
         assertAll(
-                () -> assertEquals(1, adapter.fetchReleases().size()),
                 () -> assertEquals(expected.getId(), adapter.fetchReleases().get(0).getId()),
                 () -> assertEquals(expected.getUrl(), adapter.fetchReleases().get(0).getUrl()),
                 () -> assertEquals(expected.getTimestamp(), adapter.fetchReleases().get(0).getTimestamp())
@@ -175,7 +176,7 @@ class JenkinsRepositoryAdapterTest {
     @ParameterizedTest(name = "{displayName} - [{index}] {arguments}")
     @DisplayName("skip incomplete API results")
     @MethodSource("incompleteResults")
-    void shouldSkipIncompleteJsonPayloadData(Jenkins.ApiResult incompleteResult) {
+    void skipIncompatibleApiResults(Jenkins.ApiResult incompleteResult) {
         final JenkinsClient stubClient = new StubJenkinsClient(url -> incompleteResult, url -> null);
         final JenkinsRepositoryAdapter adapter = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.STABLE, stubClient);
         assertTrue(adapter.fetchReleases().isEmpty());

--- a/src/test/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapterTest.java
+++ b/src/test/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapterTest.java
@@ -3,6 +3,7 @@
 
 package org.terasology.launcher.repositories;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -197,6 +198,7 @@ class JenkinsRepositoryAdapterTest {
 
         @Override
         Properties requestProperties(URL artifactUrl) {
+            Preconditions.checkNotNull(artifactUrl);
             return requestProperties.apply(artifactUrl);
         }
     }

--- a/src/test/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapterTest.java
+++ b/src/test/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapterTest.java
@@ -35,4 +35,19 @@ public class JenkinsRepositoryAdapterTest {
 
     Assertions.assertTrue(adapter.fetchReleases().isEmpty());  
   }
+
+  @Test
+  void fetchReleases_responseWithoutBuilds() throws IOException {
+    BufferedReader stubReader = Mockito.mock(BufferedReader.class);
+    when(stubReader.readLine()).thenReturn("");
+
+    Gson stubGson = Mockito.mock(Gson.class);
+    when(stubGson.fromJson(stubReader, Jenkins.ApiResult.class)).thenReturn(new Jenkins.ApiResult());
+
+    final JenkinsRepositoryAdapter adapter = new JenkinsRepositoryAdapter(Profile.OMEGA, Build.STABLE, stubGson);
+    final JenkinsRepositoryAdapter stub = Mockito.spy(adapter);
+    Mockito.when(stub.openConnection()).thenReturn(stubReader);
+
+    Assertions.assertTrue(adapter.fetchReleases().isEmpty());  
+  }
 }


### PR DESCRIPTION
# Testing JenkinsRepositoryAdapter - `fetchReleases`

<table>
<tr>
	<td> <b>input</b>
	<td> nothing (the adapter itself is initialized with a release specification)
<tr>
	<td> <b>action</b>
	<td> <s>IO and</s> processing of server resource(s) to internal data
<tr>
	<td> <b>output</b>
	<td> the list of available releases
</table>

## Collaborators

- `JenkinsClient`         - for requesting build information in internal format and fetch files
- `module.*`              - the internal data model
- `repositories.Jenkins`  - typed representation of the JSON model

## Behavior

- fetch Jenkins build information via `JenkinsClient`
- process the content into a list of results
- for each element in the content 
  - compute another URL from the element 
  - ~~open another connection to that URL~~ 
  - use `JenkinsClient` to fetch the content of the file
  - continue processing

## Ideas

- [x] add abstraction for IO operations (injected collaborator) -> `JenkinsClient`
- [x] only test `fetchReleases` as a unit
