### PR TITLE
chore: sort test payloads into V1 and V2 (addresses checkstyle warnings)

### DIFF
--- a/src/test/java/org/terasology/launcher/repositories/JenkinsPayload.java
+++ b/src/test/java/org/terasology/launcher/repositories/JenkinsPayload.java
@@ -5,7 +5,7 @@ package org.terasology.launcher.repositories;
 
 import java.util.List;
 
-class JenkinsPayload {
+final class JenkinsPayload {
     private JenkinsPayload() {
 
     }
@@ -127,85 +127,84 @@ class JenkinsPayload {
      */
     static class V2 {
 
-    }
+        static String validPayload() {
+            return "{\n" +
+                    "  \"builds\": [\n" +
+                    "    {\n" +
+                    "      \"artifacts\": [\n" +
+                    "        {\n" +
+                    "          \"fileName\": \"TerasologyOmega.zip\",\n" +
+                    "          \"relativePath\": \"distros/omega/build/distributions/TerasologyOmega.zip\"\n" +
+                    "        },\n" +
+                    "        {\n" +
+                    "          \"fileName\": \"versionInfo.properties\",\n" +
+                    "          \"relativePath\": \"distros/omega/versionInfo.properties\"\n" +
+                    "        }\n" +
+                    "      ],\n" +
+                    "      \"number\": 1,\n" +
+                    "      \"result\": \"SUCCESS\",\n" +
+                    "      \"timestamp\": 1604285977306,\n" +
+                    "      \"url\": \"http://jenkins.terasology.io/teraorg/job/Nanoware/job/Omega/job/develop/1/\"\n" +
+                    "    }\n" +
+                    "  ]\n" +
+                    "}";
+        }
 
-    static String validPayload() {
-        return "{\n" +
-                "  \"builds\": [\n" +
-                "    {\n" +
-                "      \"artifacts\": [\n" +
-                "        {\n" +
-                "          \"fileName\": \"TerasologyOmega.zip\",\n" +
-                "          \"relativePath\": \"distros/omega/build/distributions/TerasologyOmega.zip\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"fileName\": \"versionInfo.properties\",\n" +
-                "          \"relativePath\": \"distros/omega/versionInfo.properties\"\n" +
-                "        }\n" +
-                "      ],\n" +
-                "      \"number\": 1,\n" +
-                "      \"result\": \"SUCCESS\",\n" +
-                "      \"timestamp\": 1604285977306,\n" +
-                "      \"url\": \"http://jenkins.terasology.io/teraorg/job/Nanoware/job/Omega/job/develop/1/\"\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
-    }
+        static String nullArtifactsPayload() {
+            return "{ \n" +
+                    "  \"builds\": [\n" +
+                    "    {\n" +
+                    "      \"number\": 1, \"result\": \"SUCCESS\", \"timestamp\": 1604285977306, \n" +
+                    "      \"url\": \"http://jenkins.terasology.io/teraorg/job/Nanoware/job/Omega/job/develop/1/\"\n" +
+                    "    }\n" +
+                    "  ]\n" +
+                    "}";
+        }
 
-    static String nullArtifactsPayload() {
-        return "{ \n" +
-                "  \"builds\": [\n" +
-                "    {\n" +
-                "      \"number\": 1, \"result\": \"SUCCESS\", \"timestamp\": 1604285977306, \n" +
-                "      \"url\": \"http://jenkins.terasology.io/teraorg/job/Nanoware/job/Omega/job/develop/1/\"\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
-    }
+        static String emptyArtifactsPayload() {
+            return "{\n" +
+                    "  \"builds\": [\n" +
+                    "    {\n" +
+                    "      \"artifacts\": [],\n" +
+                    "      \"number\": 1,\n" +
+                    "      \"result\": \"SUCCESS\",\n" +
+                    "      \"timestamp\": 1604285977306,\n" +
+                    "      \"url\": \"http://jenkins.terasology.io/teraorg/job/Nanoware/job/Omega/job/develop/1/\"\n" +
+                    "    }\n" +
+                    "  ]\n" +
+                    "}";
+        }
 
-    static String emptyArtifactsPayload() {
-        return "{\n" +
-                "  \"builds\": [\n" +
-                "    {\n" +
-                "      \"artifacts\": [],\n" +
-                "      \"number\": 1,\n" +
-                "      \"result\": \"SUCCESS\",\n" +
-                "      \"timestamp\": 1604285977306,\n" +
-                "      \"url\": \"http://jenkins.terasology.io/teraorg/job/Nanoware/job/Omega/job/develop/1/\"\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
-    }
+        /**
+         * Both artifacts {@code versionInfo.properties} and {@code TerasologyOmega.zip} are required, this is missing one of them.
+         */
+        static String incompleteArtifactsPayload() {
+            return "{\n" +
+                    "  \"builds\": [\n" +
+                    "    {\n" +
+                    "      \"artifacts\": [\n" +
+                    "        {\n" +
+                    "          \"fileName\": \"versionInfo.properties\",\n" +
+                    "          \"relativePath\": \"distros/omega/versionInfo.properties\"\n" +
+                    "        }\n" +
+                    "      ],\n" +
+                    "      \"number\": 1,\n" +
+                    "      \"result\": \"SUCCESS\",\n" +
+                    "      \"timestamp\": 1604285977306,\n" +
+                    "      \"url\": \"http://jenkins.terasology.io/teraorg/job/Nanoware/job/Omega/job/develop/1/\"\n" +
+                    "    }\n" +
+                    "  ]\n" +
+                    "}";
+        }
 
-    /**
-     * Both artifacts {@code versionInfo.properties} and {@code TerasologyOmega.zip} are required, this is missing one of them.
-     */
-    static String incompleteArtifactsPayload() {
-        return "{\n" +
-                "  \"builds\": [\n" +
-                "    {\n" +
-                "      \"artifacts\": [\n" +
-                "        {\n" +
-                "          \"fileName\": \"versionInfo.properties\",\n" +
-                "          \"relativePath\": \"distros/omega/versionInfo.properties\"\n" +
-                "        }\n" +
-                "      ],\n" +
-                "      \"number\": 1,\n" +
-                "      \"result\": \"SUCCESS\",\n" +
-                "      \"timestamp\": 1604285977306,\n" +
-                "      \"url\": \"http://jenkins.terasology.io/teraorg/job/Nanoware/job/Omega/job/develop/1/\"\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
-    }
-
-    static List<String> incompletePayloads() {
-        return List.of(
-                "{}",
-                "{ \"builds\": [] }",
-                nullArtifactsPayload(),
-                emptyArtifactsPayload(),
-                incompleteArtifactsPayload()
-        );
+        static List<String> incompletePayloads() {
+            return List.of(
+                    "{}",
+                    "{ \"builds\": [] }",
+                    nullArtifactsPayload(),
+                    emptyArtifactsPayload(),
+                    incompleteArtifactsPayload()
+            );
+        }
     }
 }

--- a/src/test/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapterTest.java
+++ b/src/test/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapterTest.java
@@ -40,8 +40,8 @@ class JenkinsRepositoryAdapterTest {
     @BeforeAll
     static void setup() throws MalformedURLException {
         gson = new Gson();
-        validResult = gson.fromJson(JenkinsPayload.validPayload(), Jenkins.ApiResult.class);
-        incompleteResults = JenkinsPayload.incompletePayloads().stream()
+        validResult = gson.fromJson(JenkinsPayload.V2.validPayload(), Jenkins.ApiResult.class);
+        incompleteResults = JenkinsPayload.V2.incompletePayloads().stream()
                 .map(json -> gson.fromJson(json, Jenkins.ApiResult.class))
                 .collect(Collectors.toList());
         expectedArtifactUrl = new URL("http://jenkins.terasology.io/teraorg/job/Nanoware/job/Omega/job/develop/1/"


### PR DESCRIPTION
Address the checkstyle warnings recently introduced by correctly splitting the test payload data into V1 and V2 sub-classes.