### PR TITLE
build: remove jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
seems https://github.com/MovingBlocks/TerasologyLauncher/pull/636 missed an occurrence of `jcenter()`