### PR TITLE
feat: enable MangoHud on Linux

### DIFF
--- a/src/main/java/org/terasology/launcher/game/GameStarter.java
+++ b/src/main/java/org/terasology/launcher/game/GameStarter.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.launcher.game;
@@ -57,6 +57,14 @@ class GameStarter implements Callable<Process> {
         processBuilder = new ProcessBuilder(processParameters)
                 .directory(gamePath.toFile())
                 .redirectErrorStream(true);
+
+        //noinspection ConstantConditions
+        if (true) {  // MANGO
+            var env = processBuilder.environment();
+                var libMangoHud = "/usr/lib/mangohud/lib/libMangoHud_dlsym.so:/usr/lib/mangohud/lib/libMangoHud.so";
+                env.put("MANGOHUD", "1");
+                env.merge("LD_PRELOAD", libMangoHud, (s, value) -> "$value:$libMangoHud");
+        }
     }
 
     /**


### PR DESCRIPTION
Currently in proof-of-concept stage.

https://github.com/flightlessmango/MangoHud

## Implementation Notes

MangoHud does provide a wrapper script you can use to launch a process with the HUD enabled.

This PR's current implementation skips that in favor of making the relevant settings to the subprocess environment itself, because I am afraid of wrapper scripts having escaping issues when we pass options through or making process status harder to track.

While it is only a couple settings on one platform, multiplatform might get more complicated and make me reconsider that trade-off.

### Outstanding before merging
- [ ] configuration option
- [ ] platform detection (do not try to use this technique on Windows)
- [ ] confirm file locations
