### PR TITLE
fix(GameIdentifier): ignore displayVersion for equality comparisons, sometimes #kludge

### DIFF
--- a/src/main/java/org/terasology/launcher/model/GameIdentifier.java
+++ b/src/main/java/org/terasology/launcher/model/GameIdentifier.java
@@ -111,7 +111,11 @@ public class GameIdentifier {
             return false;
         }
         GameIdentifier that = (GameIdentifier) o;
-        return version.equals(that.version)
+
+        // Some repositories do not have reliable data for some fields
+        //   https://github.com/MovingBlocks/TerasologyLauncher/issues/651
+        boolean hasMeaningfulDisplayVersion = build != Build.STABLE;
+        return (!hasMeaningfulDisplayVersion || version.equals(that.version))
                 && engineVersion.equals(that.engineVersion)
                 && build == that.build
                 && profile == that.profile;

--- a/src/main/java/org/terasology/launcher/model/GameIdentifier.java
+++ b/src/main/java/org/terasology/launcher/model/GameIdentifier.java
@@ -123,7 +123,8 @@ public class GameIdentifier {
 
     @Override
     public int hashCode() {
-        return Objects.hash(version, build, profile, engineVersion);
+        boolean hasMeaningfulDisplayVersion = build != Build.STABLE;
+        return Objects.hash(hasMeaningfulDisplayVersion ? version : build, build, profile, engineVersion);
     }
 
     @Override

--- a/src/test/java/org/terasology/launcher/model/GameIdentifierTest.java
+++ b/src/test/java/org/terasology/launcher/model/GameIdentifierTest.java
@@ -1,0 +1,29 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.launcher.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class GameIdentifierTest {
+    @Test
+    void stableReleasesWithDifferentDisplayNamesAreEqual() {
+        // Some repositories do not have reliable data for some fields
+        //   https://github.com/MovingBlocks/TerasologyLauncher/issues/651
+        GameIdentifier fromGithub = new GameIdentifier("alpha-21", "5.1.1", Build.STABLE, Profile.OMEGA);
+        GameIdentifier fromInstall = new GameIdentifier("alpha-21+42", "5.1.1", Build.STABLE, Profile.OMEGA);
+
+        assertEquals(fromInstall, fromGithub);
+    }
+
+    @Test
+    void nightlyReleasesWithDifferentDisplayNamesAreNotEqual() {
+        GameIdentifier fromGithub = new GameIdentifier("alpha-21", "5.1.1", Build.NIGHTLY, Profile.OMEGA);
+        GameIdentifier fromInstall = new GameIdentifier("alpha-21+42", "5.1.1", Build.NIGHTLY, Profile.OMEGA);
+
+        assertNotEquals(fromInstall, fromGithub);
+    }
+}


### PR DESCRIPTION
**Probably rejecting this in favor of #654 & #655**

---

this adds some horrible logic to GameIdentifier.equals to work around #651 

~~I haven't seen it succeed yet. My latest run is stalling on fetching releases, I wonder if I hit the GitHub API rate limit.~~

Update: The version with the changes to `hashCode` seems to be working.