### PR TITLE
chore(JenkinsClient): use new HTTP client with better diagnostics

### DIFF
--- a/src/main/java/org/terasology/launcher/repositories/JenkinsClient.java
+++ b/src/main/java/org/terasology/launcher/repositories/JenkinsClient.java
@@ -70,7 +70,7 @@ class JenkinsClient {
         } catch (JsonSyntaxException | JsonIOException e) {
             logger.warn("Failed to read JSON from '{}'", url.toExternalForm(), e);
         } catch (URISyntaxException | IOException e) {
-            logger.warn("Failed to read from URL '{}'\n\t{}", e.getMessage(), url.toExternalForm());
+            logger.warn("Failed to read from URL '{}'\n\t{}", url.toExternalForm(), e.getMessage());
         }
         return null;
     }

--- a/src/main/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapter.java
+++ b/src/main/java/org/terasology/launcher/repositories/JenkinsRepositoryAdapter.java
@@ -14,6 +14,7 @@ import org.terasology.launcher.model.ReleaseMetadata;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -64,7 +65,13 @@ class JenkinsRepositoryAdapter implements ReleaseRepository {
 
         logger.debug("fetching releases from '{}'", apiUrl);
 
-        final Jenkins.ApiResult result = client.request(apiUrl);
+        final Jenkins.ApiResult result;
+        try {
+            result = client.request(apiUrl);
+        } catch (InterruptedException e) {
+            logger.warn("Interrupted while fetching packages from: {}", apiUrl, e);
+            return Collections.emptyList();
+        }
         if (result != null && result.builds != null) {
             for (Jenkins.Build build : result.builds) {
                 computeReleaseFrom(build).ifPresent(pkgList::add);

--- a/src/main/java/org/terasology/launcher/repositories/ReleaseRepository.java
+++ b/src/main/java/org/terasology/launcher/repositories/ReleaseRepository.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.launcher.repositories;
@@ -23,7 +23,7 @@ public interface ReleaseRepository {
      *
      * @return a list of available game releases (an empty list if fetching was not successful)
      */
-    //TODO: this should probably throw an IOException in case of connection erros so that the UI can decide whether to
+    //TODO: this should probably throw an IOException in case of connection errors so that the UI can decide whether to
     //      notify the user about that.
     List<GameRelease> fetchReleases();
 }

--- a/src/main/java/org/terasology/launcher/tasks/DownloadTask.java
+++ b/src/main/java/org/terasology/launcher/tasks/DownloadTask.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.launcher.tasks;
@@ -24,7 +24,7 @@ public final class DownloadTask extends Task<Void> implements ProgressListener {
     }
 
     @Override
-    protected Void call() {
+    protected Void call() throws InterruptedException {
         try {
             gameManager.install(release, this);
         } catch (IOException | DownloadException e) {

--- a/src/main/java/org/terasology/launcher/util/DownloadException.java
+++ b/src/main/java/org/terasology/launcher/util/DownloadException.java
@@ -1,10 +1,10 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.launcher.util;
 
 
-public final class DownloadException extends Exception {
+public final class DownloadException extends RuntimeException {
 
     private static final long serialVersionUID = -6597132435025903769L;
 

--- a/src/test/java/org/terasology/launcher/repositories/JenkinsClientTest.java
+++ b/src/test/java/org/terasology/launcher/repositories/JenkinsClientTest.java
@@ -28,7 +28,7 @@ class JenkinsClientTest {
 
     @Test
     @DisplayName("should handle IOException on request(url) gracefully")
-    void nullOnIoException() throws IOException {
+    void nullOnIoException() throws IOException, InterruptedException {
         final Gson gson = new Gson();
         final JenkinsClient client = new JenkinsClient(gson);
 
@@ -40,7 +40,7 @@ class JenkinsClientTest {
 
     @Test
     @DisplayName("can handle invalid JSON payload")
-    void canHandleInvalidJsonPayload() throws IOException {
+    void canHandleInvalidJsonPayload() throws InterruptedException {
         final Gson gson = new Gson();
         final JenkinsClient client = new JenkinsClient(gson);
 


### PR DESCRIPTION
I was trying to review another PR and I noticed none of the preview releases were showing up. One of our Jenkins-as-repository / HTTPS / redirect sorts of issues. So I tried swapping out the JenkinsClient#openStream implementation for one that used the newer HttpClient from Java 11.

We do get more control of how redirects are handled and more visibility in to the HTTP response if needed for troubleshooting.

Looks to be successfully following the redirects too.

It is also awfully verbose for this simple use case.

then I spent like two hours going through mailing list archives looking for the part where someone explained why HttpRequest takes a `URI`, not a `URL`. Surely that must have been a FAQ while it was going through its development and incubator phase, right? But I haven't found an answer yet, or even anyone on the net-dev list raising the question.