### PR TITLE
fix: pass JVM heap settings in correct order to GameStarter

### DIFF
--- a/src/main/java/org/terasology/launcher/game/GameService.java
+++ b/src/main/java/org/terasology/launcher/game/GameService.java
@@ -132,9 +132,9 @@ public class GameService extends Service<Boolean> {
         GameStarter starter;
         try {
             starter = new GameStarter(verifyNotNull(gamePath), settings.getGameDataDirectory(),
-                                          settings.getMaxHeapSize(), settings.getInitialHeapSize(),
-                                          javaParameters, gameParameters,
-                                          settings.getLogLevel());
+                    settings.getInitialHeapSize(), settings.getMaxHeapSize(),
+                    javaParameters, gameParameters,
+                    settings.getLogLevel());
         } catch (IOException e) {
             throw new RuntimeException("Error using this as a game directory: " + gamePath, e);
         }


### PR DESCRIPTION
Due to the two arguments being flipped selecting reasonable values (max memory >= min/initial memory) in the settings UI would lead to the game not starting properly with the following error message:

```
11:28:57.001 [GameService-0] INFO  o.t.launcher.game.RunGameTask - Game output: Error occurred during initialization of VM
11:28:57.001 [GameService-0] INFO  o.t.launcher.game.RunGameTask - Game output: Initial heap size set to a larger value than the maximum heap size
11:28:57.004 [GameService-0] DEBUG o.t.launcher.game.RunGameTask - Game closed with the exit value '1'.
```

Passing in the values in the right order fixes this.

