### PR TITLE
refactor: change API of Settings#load/store to use folder path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,11 @@ dependencies {
     implementation group: 'com.vdurmont', name: 'semver4j', version: '3.1.0'
     implementation group: 'com.vladsch.flexmark', name: 'flexmark-all', version: '0.62.2'
 
+
+    implementation('org.hildan.fxgson:fx-gson:4.0.0') {
+        because "de-/serialization of launcher properties to JSON"
+    }
+
     // These dependencies are only needed for running tests
 
     testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/src/main/java/org/terasology/launcher/LauncherInitTask.java
+++ b/src/main/java/org/terasology/launcher/LauncherInitTask.java
@@ -74,7 +74,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
             final Path cacheDirectory = getDirectoryFor(LauncherManagedDirectory.CACHE, userDataDirectory);
 
             // launcher settings
-            final Path settingsFile = userDataDirectory.resolve(Settings.DEFAULT_FILE_NAME);
+            final Path settingsFile = userDataDirectory.resolve(Settings.LEGACY_FILE_NAME);
             final LauncherSettings launcherSettings = getLauncherSettings(settingsFile);
 
             // validate the settings

--- a/src/main/java/org/terasology/launcher/LauncherInitTask.java
+++ b/src/main/java/org/terasology/launcher/LauncherInitTask.java
@@ -74,8 +74,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
             final Path cacheDirectory = getDirectoryFor(LauncherManagedDirectory.CACHE, userDataDirectory);
 
             // launcher settings
-            final Path settingsFile = userDataDirectory.resolve(Settings.LEGACY_FILE_NAME);
-            final LauncherSettings launcherSettings = getLauncherSettings(settingsFile);
+            final LauncherSettings launcherSettings = getLauncherSettings(userDataDirectory);
 
             // validate the settings
             LauncherSettingsValidator.validate(launcherSettings);
@@ -100,7 +99,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
             launcherSettings.setGameDataDirectory(gameDataDirectory);
             // TODO: Rewrite gameVersions.fixSettingsBuildVersion(launcherSettings);
 
-            storeLauncherSettingsAfterInit(launcherSettings, settingsFile);
+            storeLauncherSettingsAfterInit(launcherSettings, userDataDirectory);
 
             logger.trace("Creating launcher frame...");
 
@@ -158,11 +157,11 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
         return launcherDirectory;
     }
 
-    private LauncherSettings getLauncherSettings(Path settingsFile) throws LauncherStartFailedException {
+    private LauncherSettings getLauncherSettings(Path settingsPath) throws LauncherStartFailedException {
         logger.trace("Init LauncherSettings...");
         updateMessage(BundleUtils.getLabel("splash_retrieveLauncherSettings"));
 
-        final LauncherSettings settings = Optional.ofNullable(Settings.load(settingsFile)).orElse(Settings.getDefault());
+        final LauncherSettings settings = Optional.ofNullable(Settings.load(settingsPath)).orElse(Settings.getDefault());
         settings.init();
 
         logger.debug("Launcher Settings: {}", settings);
@@ -264,13 +263,13 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
         }, javafx.application.Platform::runLater).join();
     }
 
-    private void storeLauncherSettingsAfterInit(LauncherSettings launcherSettings, final Path settingsFile) throws LauncherStartFailedException {
+    private void storeLauncherSettingsAfterInit(LauncherSettings launcherSettings, final Path settingsPath) throws LauncherStartFailedException {
         logger.trace("Store LauncherSettings...");
         updateMessage(BundleUtils.getLabel("splash_storeLauncherSettings"));
         try {
-            Settings.store(launcherSettings, settingsFile);
+            Settings.store(launcherSettings, settingsPath);
         } catch (IOException e) {
-            logger.error("The launcher settings cannot be stored! '{}'", settingsFile, e);
+            logger.error("The launcher settings cannot be stored to '{}'.", settingsPath, e);
             Dialogs.showError(owner, BundleUtils.getLabel("message_error_storeSettings"));
             //TODO: should we fail here, or is it fine to work with in-memory settings?
             throw new LauncherStartFailedException();

--- a/src/main/java/org/terasology/launcher/settings/Settings.java
+++ b/src/main/java/org/terasology/launcher/settings/Settings.java
@@ -3,29 +3,122 @@
 
 package org.terasology.launcher.settings;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ListProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleListProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+import org.terasology.launcher.model.GameIdentifier;
+import org.terasology.launcher.util.JavaHeapSize;
+import org.terasology.launcher.util.Languages;
 
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Optional;
 import java.util.Properties;
 
 //TODO: should this be called `SettingsController` and also carry out some UI handling, e.g., displaying error messages
 //      to the user?
 public final class Settings {
-    public static final String DEFAULT_FILE_NAME = "TerasologyLauncherSettings.properties";
+    public static final String LEGACY_FILE_NAME = "TerasologyLauncherSettings.properties";
+    public static final String JSON_FILE_NAME = "settings.json";
 
     private static final Logger logger = LoggerFactory.getLogger(Settings.class);
 
-    private static final String COMMENT_SETTINGS = "Terasology Launcher - Settings";
+    private static Gson gson = new GsonBuilder()
+            .registerTypeAdapter(Path.class, new PathConverter())
+            .setPrettyPrinting()
+            .create();
 
-    private Settings() {
+    public final ObjectProperty<Locale> locale;
+
+    public final ObjectProperty<JavaHeapSize> maxHeapSize;
+    public final ObjectProperty<JavaHeapSize> minHeapSize;
+
+    public final ObjectProperty<Level> logLevel;
+
+    public final ObjectProperty<Path> gameDirectory;
+    public final ObjectProperty<Path> gameDataDirectory;
+
+    public final BooleanProperty keepDownloadedFiles;
+    public final BooleanProperty showPreReleases;
+    public final BooleanProperty closeLauncherAfterGameStart;
+
+    public final ObjectProperty<GameIdentifier> lastPlayedGameVersion;
+
+    public final ListProperty<String> userJavaParameters;
+    public final ListProperty<String> userGameParameters;
+
+    Settings() {
+        locale = new SimpleObjectProperty<>(Languages.getCurrentLocale());
+        maxHeapSize = new SimpleObjectProperty<>(JavaHeapSize.NOT_USED);
+        minHeapSize = new SimpleObjectProperty<>(JavaHeapSize.NOT_USED);
+        logLevel = new SimpleObjectProperty<>(Level.INFO);
+        gameDirectory = new SimpleObjectProperty<>();
+        gameDataDirectory = new SimpleObjectProperty<>();
+        keepDownloadedFiles = new SimpleBooleanProperty(false);
+        showPreReleases = new SimpleBooleanProperty(false);
+        closeLauncherAfterGameStart = new SimpleBooleanProperty(true);
+        lastPlayedGameVersion = new SimpleObjectProperty<>();
+        userJavaParameters = new SimpleListProperty<>(FXCollections.observableArrayList());
+        userGameParameters = new SimpleListProperty<>(FXCollections.observableArrayList());
     }
 
+    static Settings fromLegacy(LauncherSettings legacyLauncherSettings) {
+        Settings jsonSettings = new Settings();
+
+        jsonSettings.locale.setValue(legacyLauncherSettings.getLocale());
+        jsonSettings.maxHeapSize.setValue(legacyLauncherSettings.getMaxHeapSize());
+        jsonSettings.minHeapSize.setValue(legacyLauncherSettings.getInitialHeapSize());
+        jsonSettings.logLevel.setValue(legacyLauncherSettings.getLogLevel());
+        jsonSettings.gameDirectory.setValue(legacyLauncherSettings.getGameDirectory());
+        jsonSettings.gameDataDirectory.setValue(legacyLauncherSettings.getGameDataDirectory());
+        jsonSettings.keepDownloadedFiles.setValue(legacyLauncherSettings.isKeepDownloadedFiles());
+        jsonSettings.showPreReleases.setValue(legacyLauncherSettings.isShowPreReleases());
+        jsonSettings.closeLauncherAfterGameStart.setValue(legacyLauncherSettings.isCloseLauncherAfterGameStart());
+        jsonSettings.lastPlayedGameVersion.setValue(legacyLauncherSettings.getLastPlayedGameVersion().orElse(null));
+
+        jsonSettings.userJavaParameters.setAll(legacyLauncherSettings.getJavaParameterList());
+        jsonSettings.userGameParameters.setAll(legacyLauncherSettings.getUserGameParameterList());
+
+        return jsonSettings;
+    }
+
+    //TODO: change contract to load a file with fixed name from the path such that this method can decide on file format
     public static LauncherSettings load(final Path path) {
+        // TODO: try to load from JSON, fall-back to Properties
+        Path json = path.getParent().resolve(JSON_FILE_NAME);
+        if (Files.exists(json)) {
+            logger.debug("Loading launcher settings from '{}'.", json);
+            try (FileReader reader = new FileReader(json.toFile())) {
+                Settings jsonSettings = gson.fromJson(reader, Settings.class);
+                logger.info(jsonSettings.toString());
+            } catch (IOException e) {
+                logger.error("Error while loading launcher settings from file.", e);
+            }
+        }
         if (Files.exists(path)) {
             logger.debug("Loading launcher settings from '{}'.", path);
 
@@ -33,11 +126,16 @@ public final class Settings {
             try (InputStream inputStream = Files.newInputStream(path)) {
                 Properties properties = new Properties();
                 properties.load(inputStream);
-                return new LauncherSettings(properties);
+                LauncherSettings legacyLauncherSettings =  new LauncherSettings(properties);
+
+                Settings jsonSettings = fromLegacy(legacyLauncherSettings);
+
+                return legacyLauncherSettings;
             } catch (IOException e) {
                 logger.error("Error while loading launcher settings from file.", e);
             }
         }
+
         return null;
     }
 
@@ -47,11 +145,34 @@ public final class Settings {
             Files.createDirectories(path.getParent());
         }
         try (OutputStream outputStream = Files.newOutputStream(path)) {
-            settings.getProperties().store(outputStream, COMMENT_SETTINGS);
+            settings.getProperties().store(outputStream, "Terasology Launcher - Settings");
+        }
+
+        //TODO: For the switch, only write JSON. For some failover safety we may write both formats for one or two
+        //      releases before fully deprecating the Properties.
+        Settings jsonSettings = fromLegacy(settings);
+
+        Path jsonPath = path.getParent().resolve(JSON_FILE_NAME);
+        logger.debug("Writing launcher settings to '{}'.", jsonPath);
+        try (FileWriter writer = new FileWriter(jsonPath.toFile())) {
+            gson.toJson(jsonSettings, writer);
+            writer.flush();
         }
     }
 
     public static LauncherSettings getDefault() {
         return new LauncherSettings(new Properties());
     };
+
+    static class PathConverter implements JsonDeserializer<Path>, JsonSerializer<Path> {
+        @Override
+        public Path deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            return Paths.get(json.getAsString());
+        }
+
+        @Override
+        public JsonElement serialize(Path src, Type typeOfSrc, JsonSerializationContext context) {
+            return context.serialize(src.toString());
+        }
+    }
 }

--- a/src/main/java/org/terasology/launcher/settings/Settings.java
+++ b/src/main/java/org/terasology/launcher/settings/Settings.java
@@ -4,7 +4,6 @@
 package org.terasology.launcher.settings;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -18,6 +17,7 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
+import org.hildan.fxgson.FxGson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -34,9 +34,7 @@ import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.Properties;
 
 //TODO: should this be called `SettingsController` and also carry out some UI handling, e.g., displaying error messages
@@ -47,7 +45,7 @@ public final class Settings {
 
     private static final Logger logger = LoggerFactory.getLogger(Settings.class);
 
-    private static Gson gson = new GsonBuilder()
+    private static Gson gson = FxGson.coreBuilder()
             .registerTypeAdapter(Path.class, new PathConverter())
             .setPrettyPrinting()
             .create();
@@ -126,11 +124,7 @@ public final class Settings {
             try (InputStream inputStream = Files.newInputStream(path)) {
                 Properties properties = new Properties();
                 properties.load(inputStream);
-                LauncherSettings legacyLauncherSettings =  new LauncherSettings(properties);
-
-                Settings jsonSettings = fromLegacy(legacyLauncherSettings);
-
-                return legacyLauncherSettings;
+                return new LauncherSettings(properties);
             } catch (IOException e) {
                 logger.error("Error while loading launcher settings from file.", e);
             }

--- a/src/main/java/org/terasology/launcher/ui/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/ui/ApplicationController.java
@@ -460,9 +460,8 @@ public class ApplicationController {
      */
     private void close() {
         logger.debug("Dispose launcher frame...");
-        final Path settingsFile = launcherDirectory.resolve(Settings.LEGACY_FILE_NAME);
         try {
-            Settings.store(launcherSettings, settingsFile);
+            Settings.store(launcherSettings, launcherDirectory);
         } catch (IOException e) {
             logger.warn("Could not store current launcher settings!");
         }

--- a/src/main/java/org/terasology/launcher/ui/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/ui/ApplicationController.java
@@ -460,7 +460,7 @@ public class ApplicationController {
      */
     private void close() {
         logger.debug("Dispose launcher frame...");
-        final Path settingsFile = launcherDirectory.resolve(Settings.DEFAULT_FILE_NAME);
+        final Path settingsFile = launcherDirectory.resolve(Settings.LEGACY_FILE_NAME);
         try {
             Settings.store(launcherSettings, settingsFile);
         } catch (IOException e) {

--- a/src/main/java/org/terasology/launcher/ui/SettingsController.java
+++ b/src/main/java/org/terasology/launcher/ui/SettingsController.java
@@ -149,7 +149,7 @@ public class SettingsController {
         }
 
         // store changed settings
-        final Path settingsFile = launcherDirectory.resolve(Settings.DEFAULT_FILE_NAME);
+        final Path settingsFile = launcherDirectory.resolve(Settings.LEGACY_FILE_NAME);
         try {
             Settings.store(launcherSettings, settingsFile);
         } catch (IOException e) {

--- a/src/main/java/org/terasology/launcher/ui/SettingsController.java
+++ b/src/main/java/org/terasology/launcher/ui/SettingsController.java
@@ -149,12 +149,11 @@ public class SettingsController {
         }
 
         // store changed settings
-        final Path settingsFile = launcherDirectory.resolve(Settings.LEGACY_FILE_NAME);
         try {
-            Settings.store(launcherSettings, settingsFile);
+            Settings.store(launcherSettings, launcherDirectory);
         } catch (IOException e) {
             //TODO: unify error handling, probably to Settings a.k.a. SettingsController?
-            logger.error("The launcher settings cannot be stored! '{}'", settingsFile, e);
+            logger.error("The launcher settings cannot be stored to '{}'.", launcherDirectory, e);
             Dialogs.showError(stage, BundleUtils.getLabel("message_error_storeSettings"));
         } finally {
             ((Node) event.getSource()).getScene().getWindow().hide();

--- a/src/test/java/org/terasology/launcher/settings/TestLauncherSettings.java
+++ b/src/test/java/org/terasology/launcher/settings/TestLauncherSettings.java
@@ -103,7 +103,7 @@ class TestLauncherSettings {
             testProperties.store(output, null);
         }
 
-        launcherSettings = Settings.load(testPropertiesFile);
+        launcherSettings = Settings.load(testPropertiesFile.getParent());
         launcherSettings.init();
         assertPropertiesEqual();
     }


### PR DESCRIPTION
## Contains

Since it is the decision of `Settings` what file types to write, the file path should not be passed in from the outside. Instead, just the folder path can be controlled.

As a consequence, the exact file name(s) are an implementation detail and no longer need to be exposed by `Settings`.

## How to test

Ensure `gradlew test` is still passing. 

When starting the launcher and changing settings, they should be properly picked up after a re-start.

---

Contributes to #522

Based on #665
