### PR TITLE
Add arm64 binaries

### DIFF
--- a/config/gradle/jre.gradle
+++ b/config/gradle/jre.gradle
@@ -6,9 +6,12 @@
 def jdkVersion = '11.0.12+7' // jre version haven't jmod (needed for jlink/jpackager)
 def jreUrlFilenames = [
         Linux64   : 'linux-amd64-full.tar.gz',
+        LinuxArm  : 'linux-aarch64-full.tar.gz',
         Windows64 : 'windows-amd64-full.zip',
         Windows32 : 'windows-i586-full.zip',
+        WindowsArm: 'windows-aarch64-full.zip',
         Mac       : 'macos-amd64-full.zip'
+        MacArm    : 'macos-aarch64-full.zip'
 ]
 
 task createRelease() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for TerasologyLauncher! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

All this does is adds binaries for the JDK to allow ARM64 machines (linux, mac, and even windows!) to run the launcher.

### How to test

Try running a build.

### Outstanding before merging

None. (But you should probably update the download page once this is merged.)
