### PR TITLE
build(github): update actions

### DIFF
--- a/.github/workflows/push-validation.yml
+++ b/.github/workflows/push-validation.yml
@@ -11,31 +11,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 15
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
-        java-version: 15
-        java-package: jdk
-    - name: Cache Gradle packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle
+        distribution: 'liberica'
+        java-version: '15'
+        cache: 'gradle'
     - name: Build
       run: ./gradlew jar
     - name: Test
       env:
         JAVA_TOOL_OPTIONS: -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.verbose=true
       run: ./gradlew test
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: test-report
         path: build/reports/tests/test/
     - name: Upload Test Report
-      uses: check-run-reporter/action@v2.0.0
+      uses: check-run-reporter/action@v2.11.1
       # always run, otherwise you'll only see results for passing builds
       if: always()
       with:
@@ -45,7 +40,7 @@ jobs:
     - name: Static Code Analysis
       run: ./gradlew check -x test
     - name: Upload Checkstyle Report
-      uses: check-run-reporter/action@v2.0.0
+      uses: check-run-reporter/action@v2.11.1
       # always run, otherwise you'll only see results for passing builds
       if: always()
       with:


### PR DESCRIPTION
Update the Github actions in `push-validation`.

- `actions/setup-java` now has built-in support for Gradle caching, no need to configure `actions/cache` manually
- upgrade `actions/...` to latest versions
- upgrade `check-run-reporter` from 2.0.0 to 2.11.1
