### PR TITLE
feat: remove game profile selection (fixed on OMEGA)

### DIFF
--- a/src/main/java/org/terasology/launcher/LauncherInitTask.java
+++ b/src/main/java/org/terasology/launcher/LauncherInitTask.java
@@ -14,8 +14,6 @@ import org.kohsuke.github.GHRelease;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.launcher.game.GameManager;
-import org.terasology.launcher.model.GameIdentifier;
-import org.terasology.launcher.model.GameRelease;
 import org.terasology.launcher.model.LauncherVersion;
 import org.terasology.launcher.repositories.RepositoryManager;
 import org.terasology.launcher.settings.LauncherSettingsValidator;
@@ -37,7 +35,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -98,11 +95,11 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
 
             updateMessage(I18N.getLabel("splash_fetchReleases"));
             logger.info("Fetching game releases ...");
+            // implicitly fetches game releases and cache them
             final RepositoryManager repositoryManager = new RepositoryManager(client);
-            Set<GameRelease> releases = repositoryManager.getReleases();
 
+            // implicitly scans the game directory for installed games and cache them
             final GameManager gameManager = new GameManager(cacheDirectory, gameDirectory);
-            Set<GameIdentifier> installedGames = gameManager.getInstalledGames();
 
             logger.trace("Change LauncherSettings...");
             launcherSettings.gameDirectory.set(gameDirectory);

--- a/src/main/java/org/terasology/launcher/game/GameManager.java
+++ b/src/main/java/org/terasology/launcher/game/GameManager.java
@@ -40,10 +40,17 @@ public class GameManager {
     //TODO: should this be a map to installation metadata (install date, path, ...)?
     private final ObservableSet<GameIdentifier> installedGames;
 
+    /**
+     * Create a game manager and immediately scan the installation directory for installed games.
+     *
+     * @param cacheDirectory directory for cached downloads
+     * @param installDirectory directory for installed games
+     */
     public GameManager(Path cacheDirectory, Path installDirectory) {
         this.cacheDirectory = cacheDirectory;
         this.installDirectory = installDirectory;
         installedGames = FXCollections.observableSet();
+        //TODO: separate IO operation/remote call from construction of the manager object?
         scanInstallationDir();
     }
 

--- a/src/main/java/org/terasology/launcher/repositories/RepositoryManager.java
+++ b/src/main/java/org/terasology/launcher/repositories/RepositoryManager.java
@@ -18,6 +18,11 @@ public class RepositoryManager {
 
     private final Set<GameRelease> releases;
 
+    /**
+     * Create a repository manager and immediately fetch for game releases.
+     *
+     * @param httpClient the HTTP client to be used for remote requests
+     */
     public RepositoryManager(OkHttpClient httpClient) {
         JenkinsClient client = new JenkinsClient(httpClient, new Gson());
 
@@ -26,6 +31,7 @@ public class RepositoryManager {
 
         Set<ReleaseRepository> all = Sets.newHashSet(github, omegaNightly);
 
+        //TODO: separate IO operation/remote call from construction of the manager object?
         releases = fetchReleases(all);
     }
 

--- a/src/main/java/org/terasology/launcher/ui/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/ui/ApplicationController.java
@@ -178,7 +178,7 @@ public class ApplicationController {
     private void initComboBoxes() {
         profileComboBox.setCellFactory(list -> new GameProfileCell());
         profileComboBox.setButtonCell(new GameProfileCell());
-        profileComboBox.setItems(FXCollections.observableList(Arrays.asList(Profile.values().clone())));
+        profileComboBox.setItems(FXCollections.observableList(Arrays.asList(Profile.OMEGA)));
         ReadOnlyObjectProperty<Profile> selectedProfile = profileComboBox.getSelectionModel().selectedItemProperty();
         // control what game release is selected when switching profiles. this is a reaction to a change of the selected
         // profile to perform a one-time action to select a game release. afterwards, the user is in control of what is

--- a/src/main/java/org/terasology/launcher/ui/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/ui/ApplicationController.java
@@ -8,7 +8,6 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.binding.ObjectBinding;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.Property;
-import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableValue;
@@ -46,13 +45,12 @@ import org.terasology.launcher.repositories.RepositoryManager;
 import org.terasology.launcher.settings.Settings;
 import org.terasology.launcher.tasks.DeleteTask;
 import org.terasology.launcher.tasks.DownloadTask;
-import org.terasology.launcher.util.I18N;
 import org.terasology.launcher.util.HostServices;
+import org.terasology.launcher.util.I18N;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.ResourceBundle;
@@ -79,6 +77,8 @@ public class ApplicationController {
 
     private Stage stage;
 
+    private Property<LauncherConfiguration> config;
+
     private Property<GameRelease> selectedRelease;
     private Property<GameAction> gameAction;
     private BooleanProperty downloading;
@@ -91,8 +91,6 @@ public class ApplicationController {
      */
     private final Property<Optional<Warning>> warning;
 
-    @FXML
-    private ComboBox<Profile> profileComboBox;
     @FXML
     private ComboBox<GameRelease> gameReleaseComboBox;
     @FXML
@@ -130,6 +128,8 @@ public class ApplicationController {
         gameService.setOnFailed(this::handleRunFailed);
         gameService.valueProperty().addListener(this::handleRunStarted);
 
+        config = new SimpleObjectProperty<>();
+
         downloading = new SimpleBooleanProperty(false);
         showPreReleases = new SimpleBooleanProperty(false);
 
@@ -163,6 +163,37 @@ public class ApplicationController {
         initComboBoxes();
         initButtons();
         setLabelStrings();
+
+        cancelDownloadButton.setTooltip(I18N.createTooltip(I18N.labelBinding("launcher_cancelDownload")));
+        startButton.setTooltip(I18N.createTooltip(I18N.labelBinding("launcher_start")));
+        downloadButton.setTooltip(I18N.createTooltip(I18N.labelBinding("launcher_download")));
+        deleteButton.setTooltip(I18N.createTooltip(I18N.labelBinding("launcher_delete")));
+        settingsButton.setTooltip(I18N.createTooltip(I18N.labelBinding("launcher_settings")));
+        exitButton.setTooltip(I18N.createTooltip(I18N.labelBinding("launcher_exit")));
+
+        // add Logback appender to both the root logger and the tab
+        Logger rootLogger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        if (rootLogger instanceof ch.qos.logback.classic.Logger) {
+            ch.qos.logback.classic.Logger logbackLogger = (ch.qos.logback.classic.Logger) rootLogger;
+
+            logViewController.setContext(logbackLogger.getLoggerContext());
+            logViewController.start(); // CHECK: do I really need to start it manually here?
+            logbackLogger.addAppender(logViewController);
+        }
+
+        //TODO: This only updates when the launcher is initialized (which should happen exactly once o.O)
+        //      We should update this value at least every time the download directory changes (user setting).
+        //      Ideally, we would check periodically for disk space.
+        warning.bind(Bindings.createObjectBinding(() -> {
+            logger.info("Checking for remaining disk space ...");
+            LauncherConfiguration cfg = config.getValue();
+            if (cfg != null && cfg.getDownloadDirectory().toFile().getUsableSpace() <= MINIMUM_FREE_SPACE) {
+                return Optional.of(Warning.LOW_ON_SPACE);
+            } else {
+                return Optional.empty();
+            }
+        }, config, installedGames));
+
     }
 
     /**
@@ -176,19 +207,15 @@ public class ApplicationController {
      * to the selected profile, and derive the currently selected release from the combo box's selection model.
      */
     private void initComboBoxes() {
-        profileComboBox.setCellFactory(list -> new GameProfileCell());
-        profileComboBox.setButtonCell(new GameProfileCell());
-        profileComboBox.setItems(FXCollections.observableList(Arrays.asList(Profile.OMEGA)));
-        ReadOnlyObjectProperty<Profile> selectedProfile = profileComboBox.getSelectionModel().selectedItemProperty();
-        // control what game release is selected when switching profiles. this is a reaction to a change of the selected
-        // profile to perform a one-time action to select a game release. afterwards, the user is in control of what is
-        // selected
-        selectedProfile.addListener((obs, oldVal, newVal) -> {
+        // derive the releases to display from the selected profile (`selectedProfile`). the resulting list is ordered
+        // in the way the launcher is supposed to display the versions (currently by release timestamp).
+        config.addListener((obs, oldVal, cfg) -> {
             ObservableList<GameRelease> availableReleases = gameReleaseComboBox.getItems();
-            GameIdentifier lastPlayedGame = launcherSettings.lastPlayedGameVersion.get();
+            GameIdentifier lastPlayedGame = cfg.getLauncherSettings().lastPlayedGameVersion.get();
 
             Optional<GameRelease> lastPlayed = availableReleases.stream()
                     .filter(release -> release.getId().equals(lastPlayedGame))
+                    .filter(release -> installedGames.contains(release.getId()))
                     .findFirst();
             Optional<GameRelease> lastInstalled = availableReleases.stream()
                     .filter(release -> installedGames.contains(release.getId()))
@@ -200,20 +227,21 @@ public class ApplicationController {
                     .orElse(null));
         });
 
-        // derive the releases to display from the selected profile (`selectedProfile`). the resulting list is ordered
-        // in the way the launcher is supposed to display the versions (currently by release timestamp).
         final ObjectBinding<ObservableList<GameRelease>> releases = Bindings.createObjectBinding(() -> {
-            if (repositoryManager == null) {
+            LauncherConfiguration cfg = config.getValue();
+            if (cfg == null || cfg.getRepositoryManager() == null) {
                 return FXCollections.emptyObservableList();
+            } else {
+                RepositoryManager mngr = config.getValue().getRepositoryManager();
+                List<GameRelease> releasesForProfile =
+                        mngr.getReleases().stream()
+                                .filter(release -> release.getId().getProfile() == Profile.OMEGA)
+                                .filter(release -> showPreReleases.getValue() || release.getId().getBuild().equals(Build.STABLE))
+                                .sorted(ApplicationController::compareReleases)
+                                .collect(Collectors.toList());
+                return FXCollections.observableList(releasesForProfile);
             }
-            List<GameRelease> releasesForProfile =
-                    repositoryManager.getReleases().stream()
-                            .filter(release -> release.getId().getProfile() == selectedProfile.get())
-                            .filter(release -> showPreReleases.getValue() || release.getId().getBuild().equals(Build.STABLE))
-                            .sorted(ApplicationController::compareReleases)
-                            .collect(Collectors.toList());
-            return FXCollections.observableList(releasesForProfile);
-        }, selectedProfile, showPreReleases);
+        }, config, showPreReleases);
 
         gameReleaseComboBox.itemsProperty().bind(releases);
         gameReleaseComboBox.buttonCellProperty().bind(Bindings.createObjectBinding(() -> new GameReleaseCell(installedGames, true), installedGames));
@@ -262,6 +290,8 @@ public class ApplicationController {
 
     @SuppressWarnings("checkstyle:HiddenField")
     public void update(final LauncherConfiguration configuration, final Stage stage, final HostServices hostServices) {
+        this.config.setValue(configuration);
+
         this.launcherDirectory = configuration.getLauncherDirectory();
         this.launcherSettings = configuration.getLauncherSettings();
         this.showPreReleases.bind(launcherSettings.showPreReleases);
@@ -275,37 +305,7 @@ public class ApplicationController {
         // get notified if the installed games are changed from a different thread (DeleteTask or DownloadTask).
         Bindings.bindContent(installedGames, gameManager.getInstalledGames());
 
-        profileComboBox.getSelectionModel().select(
-                Optional.ofNullable(launcherSettings.lastPlayedGameVersion.get())
-                        .map(GameIdentifier::getProfile).orElse(Profile.OMEGA)
-        );
-
-        // add Logback appender to both the root logger and the tab
-        Logger rootLogger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-        if (rootLogger instanceof ch.qos.logback.classic.Logger) {
-            ch.qos.logback.classic.Logger logbackLogger = (ch.qos.logback.classic.Logger) rootLogger;
-
-            logViewController.setContext(logbackLogger.getLoggerContext());
-            logViewController.start(); // CHECK: do I really need to start it manually here?
-            logbackLogger.addAppender(logViewController);
-        }
-
-        //TODO: This only updates when the launcher is initialized (which should happen exactly once o.O)
-        //      We should update this value at least every time the download directory changes (user setting).
-        //      Ideally, we would check periodically for disk space.
-        if (configuration.getDownloadDirectory().toFile().getUsableSpace() <= MINIMUM_FREE_SPACE) {
-            warning.setValue(Optional.of(Warning.LOW_ON_SPACE));
-        } else {
-            warning.setValue(Optional.empty());
-        }
         footerController.setHostServices(hostServices);
-
-        cancelDownloadButton.setTooltip(I18N.createTooltip(I18N.labelBinding("launcher_cancelDownload")));
-        startButton.setTooltip(I18N.createTooltip(I18N.labelBinding("launcher_start")));
-        downloadButton.setTooltip(I18N.createTooltip(I18N.labelBinding("launcher_download")));
-        deleteButton.setTooltip(I18N.createTooltip(I18N.labelBinding("launcher_delete")));
-        settingsButton.setTooltip(I18N.createTooltip(I18N.labelBinding("launcher_settings")));
-        exitButton.setTooltip(I18N.createTooltip(I18N.labelBinding("launcher_exit")));
     }
 
     @FXML
@@ -416,7 +416,6 @@ public class ApplicationController {
         downloadTask = new DownloadTask(gameManager, selectedRelease.getValue());
         downloading.bind(downloadTask.runningProperty());
 
-        profileComboBox.disableProperty().bind(downloadTask.runningProperty());
         gameReleaseComboBox.disableProperty().bind(downloadTask.runningProperty());
         progressBar.visibleProperty().bind(downloadTask.runningProperty());
 

--- a/src/main/java/org/terasology/launcher/util/I18N.java
+++ b/src/main/java/org/terasology/launcher/util/I18N.java
@@ -147,6 +147,7 @@ public final class I18N {
         return messageFormat.format(arguments, new StringBuffer(), null).toString();
     }
 
+    //TODO: move to 'Resources' helper class, unrelated to I18n
     public static URI getURI(String key) {
         final String uriStr = ResourceBundle.getBundle(URI_BUNDLE, getCurrentLocale()).getString(key);
         try {

--- a/src/main/resources/org/terasology/launcher/views/application.fxml
+++ b/src/main/resources/org/terasology/launcher/views/application.fxml
@@ -105,8 +105,6 @@
                   <children>
                     <VBox alignment="CENTER_LEFT" prefHeight="200.0" prefWidth="100.0" spacing="8.0" HBox.hgrow="ALWAYS">
                       <children>
-                        <ComboBox fx:id="profileComboBox" maxWidth="1.7976931348623157E308" disable="true">
-                        </ComboBox>
                         <ComboBox fx:id="gameReleaseComboBox" maxWidth="1.7976931348623157E308">
                         </ComboBox>
                       </children>

--- a/src/main/resources/org/terasology/launcher/views/application.fxml
+++ b/src/main/resources/org/terasology/launcher/views/application.fxml
@@ -105,23 +105,9 @@
                   <children>
                     <VBox alignment="CENTER_LEFT" prefHeight="200.0" prefWidth="100.0" spacing="8.0" HBox.hgrow="ALWAYS">
                       <children>
-                        <ComboBox fx:id="profileComboBox" maxWidth="1.7976931348623157E308">
-                          <items>
-                            <FXCollections fx:factory="observableArrayList">
-                              <String fx:value="Item 1" />
-                              <String fx:value="Item 2" />
-                              <String fx:value="Item 3" />
-                            </FXCollections>
-                          </items>
+                        <ComboBox fx:id="profileComboBox" maxWidth="1.7976931348623157E308" disable="true">
                         </ComboBox>
                         <ComboBox fx:id="gameReleaseComboBox" maxWidth="1.7976931348623157E308">
-                          <items>
-                            <FXCollections fx:factory="observableArrayList">
-                              <String fx:value="Item 1" />
-                              <String fx:value="Item 2" />
-                              <String fx:value="Item 3" />
-                            </FXCollections>
-                          </items>
                         </ComboBox>
                       </children>
                       <padding>


### PR DESCRIPTION
### Contains

- chore: remove unused code; add doc comments
- feat: disable game profile selection (fixed on OMEGA)
- feat: remove profile box from both FXML and `ApplicationController`
- fix: check for remaining disk space each time the installed games change
- chore: move more initialization code from `ApplicationController#update` to `ApplicationController#initialize`
- feat: use more bindings in `FooterController`

Contributes to #677.

![image](https://user-images.githubusercontent.com/1448874/200142114-9d254285-8976-4fa5-9376-785e69a6ff47.png)

### How to test

Start the launcher.

The game profile selection box ("Terasology" vs "Terasology Lite") should no longer be visible.

The game release selection box should contain the releases (and pre-releases, if enabled in the settings) of Omega builds.

Downloading and starting Omega releases should still work as before.

> **Note:** Previously installed engine-only releases will no longer be visible in the launcher, but will remain on the disk (dead data, but can be started manually).

### Outstanding before merging

- [x] remove binding in `ApplicationController#downloadAction`
    https://github.com/MovingBlocks/TerasologyLauncher/blob/d973d4f3a50ac34024746acc0611f705dd4fc213/src/main/java/org/terasology/launcher/ui/ApplicationController.java#L419

Improve on the UI in a follow-up PR and clean up unused code in the progress.
