### PR TITLE
test: add test to ensure that all supported languages have language flag icons

### DIFF
--- a/src/test/java/org/terasology/launcher/util/ResourceTests.java
+++ b/src/test/java/org/terasology/launcher/util/ResourceTests.java
@@ -1,0 +1,29 @@
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.launcher.util;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testfx.framework.junit5.ApplicationExtension;
+
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(ApplicationExtension.class)
+class ResourceTests {
+
+    private static Stream<Arguments> provideSupportedLocales() {
+        return I18N.getSupportedLocales().stream().map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSupportedLocales")
+    void ensureAllSupportedLocalesHaveFlagIcons(Locale locale) {
+        assertNotNull(I18N.getFxImage("flag_" + locale.toLanguageTag()));
+    }
+}


### PR DESCRIPTION
### Contains

A simple (JavaFX) unit test to ensure that the flag icons for the supported locales can be loaded.

### How to test

Run the new test to check that it succeeds.

```
gradlew test
```

I checked the negative case locally by adding a new locale (`new Locale("nl")`)  to the list of supported locales in `I18N.java` and observed test failure for that locale, as would be expected.

### Outstanding before merging

Nothing.
