### PR TITLE
fix: updated the download URL

### DIFF
--- a/src/main/java/org/terasology/launcher/LauncherInitTask.java
+++ b/src/main/java/org/terasology/launcher/LauncherInitTask.java
@@ -204,7 +204,7 @@ public class LauncherInitTask extends Task<LauncherConfiguration> {
     }
 
     private void showDownloadPage() {
-        final String downloadPage = "https://terasology.org/download";
+        final String downloadPage = "https://terasology.org/downloads/";
         try {
             hostServices.tryOpenUri(new URI(downloadPage));
         } catch (URISyntaxException e) {


### PR DESCRIPTION
-Updated the download URL from https://terasology.org/download to https://terasology.org/downloads/

Fixes #690 