### PR TITLE
chore: handle offline mode more graceful

### DIFF
--- a/src/main/java/org/terasology/launcher/repositories/GithubRepositoryAdapter.java
+++ b/src/main/java/org/terasology/launcher/repositories/GithubRepositoryAdapter.java
@@ -11,6 +11,7 @@ import org.kohsuke.github.GHRelease;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
+import org.kohsuke.github.HttpException;
 import org.kohsuke.github.extras.okhttp3.OkHttpConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +41,14 @@ public class GithubRepositoryAdapter implements ReleaseRepository {
                     .withConnector(new OkHttpConnector(httpClient))
                     .build();
             logger.debug("Github rate limit: {}", github.getRateLimit());
+        } catch (HttpException e) {
+            if (e.getResponseCode() == -1) {
+                // no internet connection, do nothing
+            } else {
+                e.printStackTrace();
+            }
         } catch (IOException e) {
+
             e.printStackTrace();
         }
     }
@@ -83,6 +91,12 @@ public class GithubRepositoryAdapter implements ReleaseRepository {
                         .collect(Collectors.toList());
                 logger.debug("Github rate limit: {}", github.getRateLimit());
                 return releases;
+            } catch (HttpException e) {
+                if (e.getResponseCode() == -1) {
+                    // no internet connection, do nothing
+                } else {
+                    e.printStackTrace();
+                }
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/src/main/java/org/terasology/launcher/repositories/GithubRepositoryAdapter.java
+++ b/src/main/java/org/terasology/launcher/repositories/GithubRepositoryAdapter.java
@@ -42,7 +42,7 @@ public class GithubRepositoryAdapter implements ReleaseRepository {
                     .build();
             logger.debug("Github rate limit: {}", github.getRateLimit());
         } catch (HttpException e) {
-            if (e.getResponseCode() == -1) {
+            if (e.getResponseCode() == -1) { // NOPMD
                 // no internet connection, do nothing
             } else {
                 e.printStackTrace();
@@ -92,7 +92,7 @@ public class GithubRepositoryAdapter implements ReleaseRepository {
                 logger.debug("Github rate limit: {}", github.getRateLimit());
                 return releases;
             } catch (HttpException e) {
-                if (e.getResponseCode() == -1) {
+                if (e.getResponseCode() == -1) { // NOPMD
                     // no internet connection, do nothing
                 } else {
                     e.printStackTrace();


### PR DESCRIPTION
### Contains

Instead of blindly logging the stacktrace of exceptions the launcher now checks for an `HTTPException` and whether the status code is -1, indiciating a network issue, for instance, when running offline.

Thus, we should only log in exceptional cases.

This does not affect any functionality of the launcher when run offline, though.

### How to test

Start the launcher when offline and observe the logs. There should be less stacktraces printed from the GitHub repository adapter.

### Outstanding before merging

Nothing.
