### PR TITLE
fix(settings): stop writing legacy configuration file

### DIFF
--- a/src/main/java/org/terasology/launcher/settings/LauncherSettings.java
+++ b/src/main/java/org/terasology/launcher/settings/LauncherSettings.java
@@ -65,7 +65,7 @@ public class LauncherSettings {
     static final String LAST_PLAYED_GAME_VERSION_DEFAULT = "";
     static final String LAST_INSTALLED_GAME_VERSION_DEFAULT = "";
 
-    static final String LAUNCHER_SETTINGS_FILE_NAME = "TerasologyLauncherSettings.properties";
+    static final String LAUNCHER_LEGACY_SETTINGS_FILE_NAME = "TerasologyLauncherSettings.properties";
 
     private final Properties properties;
 

--- a/src/main/java/org/terasology/launcher/settings/Settings.java
+++ b/src/main/java/org/terasology/launcher/settings/Settings.java
@@ -29,7 +29,6 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -105,26 +104,6 @@ public final class  Settings {
         return jsonSettings;
     }
 
-    static LauncherSettings toLegacy(Settings settings) {
-        LauncherSettings legacy = new LauncherSettings(new Properties());
-
-        legacy.setLocale(settings.locale.get());
-        legacy.setMaxHeapSize(settings.maxHeapSize.get());
-        legacy.setInitialHeapSize(settings.minHeapSize.get());
-        legacy.setLogLevel(settings.logLevel.get());
-        legacy.setGameDirectory(settings.gameDirectory.get());
-        legacy.setGameDirectory(settings.gameDataDirectory.get());
-        legacy.setKeepDownloadedFiles(settings.keepDownloadedFiles.get());
-        legacy.setShowPreReleases(settings.showPreReleases.get());
-        legacy.setCloseLauncherAfterGameStart(settings.closeLauncherAfterGameStart.get());
-        legacy.setLastPlayedGameVersion(settings.lastPlayedGameVersion.get());
-
-        legacy.setUserJavaParameters(String.join(" ", settings.userJavaParameters.get()));
-        legacy.setUserGameParameters(String.join(" ", settings.userGameParameters.get()));
-
-        return legacy;
-    }
-
     /**
      * Load the launcher settings from disk.
      *
@@ -168,20 +147,13 @@ public final class  Settings {
     }
 
     /**
-     * Write the launcher settings to disk.
+     * Write the launcher settings to disk in JSON format.
      *
      * The given {@code path} must be the direct parent folder of where the launcher settings should be stored.
      *
-     * The launcher settings are persisted to different formats (to have a fail-over phase before deprecating the legacy
-     * format). Calling this method will store the settings in the following format:
-     * <ul>
-     *     <li>JSON</li>
-     *     <li>Java {@link Properties}</li>
-     * </ul>
-     *
      * @param settings the launcher settings to persist
      * @param path the path to the folder where the launcher settings file should be written to
-     * @throws IOException
+     * @throws IOException if the file cannot be written
      */
     public static synchronized void store(final Settings settings, final Path path) throws IOException {
         logger.debug("Writing launcher settings to '{}'.", path);
@@ -189,13 +161,6 @@ public final class  Settings {
             Files.createDirectories(path);
         }
 
-        Path legacyPath = path.resolve(LEGACY_FILE_NAME);
-        try (OutputStream outputStream = Files.newOutputStream(legacyPath)) {
-            toLegacy(settings).getProperties().store(outputStream, "Terasology Launcher - Settings");
-        }
-
-        //TODO: For the switch, only write JSON. For some failover safety we may write both formats for one or two
-        //      releases before fully deprecating the Properties.
         Path jsonPath = path.resolve(JSON_FILE_NAME);
         logger.debug("Writing launcher settings to '{}'.", jsonPath);
         try (FileWriter writer = new FileWriter(jsonPath.toFile())) {

--- a/src/test/java/org/terasology/launcher/settings/TestLauncherSettings.java
+++ b/src/test/java/org/terasology/launcher/settings/TestLauncherSettings.java
@@ -67,7 +67,7 @@ class TestLauncherSettings {
 
     @BeforeEach
     void setup() {
-        testPropertiesFile = tempDirectory.resolve(LauncherSettings.LAUNCHER_SETTINGS_FILE_NAME);
+        testPropertiesFile = tempDirectory.resolve(LauncherSettings.LAUNCHER_LEGACY_SETTINGS_FILE_NAME);
 
         launcherSettings = Settings.getDefault();
     }


### PR DESCRIPTION
Removes code that wrote to a legacy TerasologyLauncherSettings.properties
Still reads from the legacy file if it cannot find the new JSON config


### Contains

Deletes some code that was marked for deletion via code comments

### How to test

1. Build the launcher with the changes in this PR
2. Find the directory where the launcher stores its configuration files. On Windows, it's under <user>/AppData/Roaming/TerasologyLauncher by default
3. However you prefer, create or modify your own TerasologyLauncherSettings.properties to include these modified field values: 

```
maxHeapSize=MB_512
initialHeapSize=MB_512
```
4. If settings.json exists, delete it.
5. Run the development build of the launcher.
6. It will prompt you to select a game data folder (this is the current behavior of the release version of the launcher). Go ahead and do that.
7. In the Launcher settings, verify that minHeap and maxHeap are set to 512MB, as specified in the legacy properties file.
8. If so, good. Continue.
9. Exit the Launcher. Notice that a new settings.json was written with the MB_512 values.
10. If so, good. Continue.
11. Delete TerasologyLauncherSettings.properties
12. In settings.json, change the MB_512 values to GB_1 for maxHeapSize and minHeapSize
13. Run the Launcher again.
14. It will *not* prompt you to select a game data folder (this is the current behavior of the release version of the launcher).
15. Go to the launcher's settings and verify that minHeap and maxHeap are set to 1GB.
16. Close the launcher.
17. Notice that the launcher did *not* write a new TerasologyLauncherSettings.properties. Good, that's the intended change.
18. END

### Outstanding before merging
Nothing comes to mind.
