### PR TITLE
feat: prepare runtime management

### DIFF
--- a/src/main/java/org/terasology/launcher/game/GameService.java
+++ b/src/main/java/org/terasology/launcher/game/GameService.java
@@ -118,7 +118,7 @@ public class GameService extends Service<Boolean> {
      * @throws RuntimeException when required files in the game directory are missing or inaccessible
      */
     @Override
-    protected RunGameTask createTask() {
+    protected RunGameTask createTask() throws GameVersionNotSupportedException{
         verifyNotNull(settings);
 
         GameStarter starter;

--- a/src/main/java/org/terasology/launcher/game/GameVersionNotSupportedException.java
+++ b/src/main/java/org/terasology/launcher/game/GameVersionNotSupportedException.java
@@ -1,0 +1,19 @@
+// Copyright 2023 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.launcher.game;
+
+import com.vdurmont.semver4j.Semver;
+
+public class GameVersionNotSupportedException extends RuntimeException {
+    private final Semver engineVersion;
+
+    public GameVersionNotSupportedException(Semver engineVersion) {
+        this.engineVersion = engineVersion;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Unsupported engine version: " + engineVersion.toString();
+    }
+}

--- a/src/main/java/org/terasology/launcher/game/VersionHistory.java
+++ b/src/main/java/org/terasology/launcher/game/VersionHistory.java
@@ -13,10 +13,20 @@ import com.vdurmont.semver4j.Semver;
 public enum VersionHistory {
     /**
      * The preview release of v4.1.0-rc.1 is the first release with LWJGL v3.
-     * See https://github.com/MovingBlocks/Terasology/releases/tag/v4.1.0-rc.1
+     * See <a href="https://github.com/MovingBlocks/Terasology/releases/tag/v4.1.0-rc.1">v4.1.0-rc.1</a>
      */
     LWJGL3("4.1.0-rc.1"),
-    PICOCLI("5.2.0-SNAPSHOT");
+
+    /**
+     * With the 5.2.0-rc.1 preview release Terasology switches to PICOCLI with POSIX-style command line options.
+     * See <a href="https://github.com/MovingBlocks/Terasology/releases/tag/v5.2.0-rc.1">v5.2.0-rc.1</a>
+     */
+    PICOCLI("5.2.0-SNAPSHOT"),
+
+    /** Since 3aa68c04f192243575f7f78de5b6ce268bb2da1a Terasology requires at least Java 17.
+     * See <a href="https://github.com/MovingBlocks/Terasology/commit/3aa68c04f192243575f7f78de5b6ce268bb2da1a">3aa68c04</a>
+     */
+    JAVA17("6.0.0-SNAPSHOT");
 
     public final Semver engineVersion;
 

--- a/src/main/java/org/terasology/launcher/ui/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/ui/ApplicationController.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.launcher.LauncherConfiguration;
 import org.terasology.launcher.game.GameManager;
 import org.terasology.launcher.game.GameService;
+import org.terasology.launcher.game.GameVersionNotSupportedException;
 import org.terasology.launcher.game.Installation;
 import org.terasology.launcher.model.Build;
 import org.terasology.launcher.model.GameIdentifier;
@@ -74,21 +75,21 @@ public class ApplicationController {
     private Settings launcherSettings;
 
     private GameManager gameManager;
-    private RepositoryManager repositoryManager;
+
     private final GameService gameService;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private DownloadTask downloadTask;
 
     private Stage stage;
 
-    private Property<LauncherConfiguration> config;
+    private final Property<LauncherConfiguration> config;
 
-    private Property<GameRelease> selectedRelease;
-    private Property<GameAction> gameAction;
-    private BooleanProperty downloading;
-    private BooleanProperty showPreReleases;
+    private final Property<GameRelease> selectedRelease;
+    private final Property<GameAction> gameAction;
+    private final BooleanProperty downloading;
+    private final BooleanProperty showPreReleases;
 
-    private ObservableSet<GameIdentifier> installedGames;
+    private final ObservableSet<GameIdentifier> installedGames;
 
     /**
      * Indicate whether the user's hard drive is running out of space for game downloads.
@@ -331,7 +332,6 @@ public class ApplicationController {
         this.launcherSettings = configuration.getLauncherSettings();
         this.showPreReleases.bind(launcherSettings.showPreReleases);
 
-        this.repositoryManager = configuration.getRepositoryManager();
         this.gameManager = configuration.getGameManager();
 
         this.stage = stage;
@@ -411,7 +411,11 @@ public class ApplicationController {
             Dialogs.showError(stage, I18N.getMessage("message_error_installationNotFound", release));
             return;
         }
-        gameService.start(installation, launcherSettings);
+        try {
+            gameService.start(installation, launcherSettings);
+        } catch (GameVersionNotSupportedException e) {
+            Dialogs.showError(stage, e.getMessage());
+        }
     }
 
     private void handleRunStarted(ObservableValue<? extends Boolean> o, Boolean oldValue, Boolean newValue) {

--- a/src/main/java/org/terasology/launcher/ui/ApplicationController.java
+++ b/src/main/java/org/terasology/launcher/ui/ApplicationController.java
@@ -60,7 +60,6 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -494,21 +493,6 @@ public class ApplicationController {
                     final DeleteTask deleteTask = new DeleteTask(gameManager, id);
                     executor.submit(deleteTask);
                 });
-    }
-
-    /**
-     * Select the first item matching given predicate, select the first item otherwise.
-     *
-     * @param comboBox  the combo box to change the selection for
-     * @param predicate first item matching this predicate will be selected
-     */
-    private <T> void selectItem(final ComboBox<T> comboBox, Predicate<T> predicate) {
-        final T item = comboBox.getItems().stream()
-                .filter(predicate)
-                .findFirst()
-                .orElse(comboBox.getItems().get(0));
-
-        comboBox.getSelectionModel().select(item);
     }
 
     /**

--- a/src/test/java/org/terasology/launcher/game/TestGameStarter.java
+++ b/src/test/java/org/terasology/launcher/game/TestGameStarter.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.launcher.game;
 
+import com.vdurmont.semver4j.Semver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,9 +20,11 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.terasology.launcher.Matchers.hasItemsFrom;
 
 public class TestGameStarter {
@@ -65,11 +68,12 @@ public class TestGameStarter {
 
     @Test
     public void testJre() throws IOException {
+        Semver engineVersion = new Semver("5.0.0");
         GameStarter task = newStarter();
         // This is the sort of test where the code under test and the expectation are just copies
         // of the same source. But since there's a plan to separate the launcher runtime from the
         // game runtime, the runtime location seemed like a good thing to specify in its own test.
-        assertTrue(task.getRuntimePath().startsWith(Path.of(System.getProperty("java.home"))));
+        assertTrue(task.getRuntimePath(engineVersion).startsWith(Path.of(System.getProperty("java.home"))));
     }
 
     static Stream<Arguments> provideJarPaths() {
@@ -94,5 +98,19 @@ public class TestGameStarter {
         // TODO: heap min, heap max, log level
         // could parameterize this test for the things that are optional?
         // heap min, heap max, log level, gameParams and javaParams are all optional.
+    }
+
+    @Test
+    public void testSupportedJava11() throws IOException {
+        Semver engineVersion = new Semver("5.3.0");
+        GameStarter task = newStarter();
+        assertDoesNotThrow(() -> task.getRuntimePath(engineVersion));
+    }
+
+    @Test
+    public void testUnsupportedJava17() throws IOException {
+        Semver engineVersion = new Semver("6.0.0");
+        GameStarter task = newStarter();
+        assertThrows(GameVersionNotSupportedException.class, () -> task.getRuntimePath(engineVersion));
     }
 }


### PR DESCRIPTION
### Contains

To prepare for Java runtime management in the launcher  this PR introduces 

- an entry to `VersionHistory` to denote the first (upcoming) game release to require Java 17
- add a new checked exception to bail out in case the launcher tries to start an unsupported version

In this state, the user experience is not great, but at least the launcher is not crashing an the error message shows a somewhat useful message.

This could be released as a minor or patch release to harden the launcher against new releases and release candidates requiring that no longe work with the Java 11 shipped with the launcher.

### How to test

Start the launcher and check that everything is working as expected.

To see the error message you can change the version in `VersionHistory.JAVA17` to something lower like `4.0.0` and try to download and run the latest 5.3.0 release. 
The launcher should show an error message, but otherwise handle the issue gracefully.

### Outstanding before merging

Nothing.
