### PR TITLE
fix: handle unsuccessful requests in JenkinsClient better

### DIFF
--- a/src/main/java/org/terasology/launcher/repositories/JenkinsClient.java
+++ b/src/main/java/org/terasology/launcher/repositories/JenkinsClient.java
@@ -69,7 +69,11 @@ class JenkinsClient {
         var request = new Request.Builder().url(url).build();
         try (var response = client.newCall(request).execute()) {
             logger.debug("{}{}", response, response.cacheResponse() != null ? " (cached)" : "");
-            return gson.fromJson(response.body().string(), Jenkins.ApiResult.class);
+            if (response.isSuccessful()) {
+                return gson.fromJson(response.body().string(), Jenkins.ApiResult.class);
+            } else {
+                logger.warn("Failed to read from URL '{}' with status code {}.", url.toExternalForm(), response.code());
+            }
         } catch (JsonSyntaxException | JsonIOException e) {
             logger.warn("Failed to read JSON from '{}'", url.toExternalForm(), e);
         } catch (IOException e) {


### PR DESCRIPTION
### Contains

A small change to handle unsuccessful requests via the `JenkinsClient` more gracefully.

Currently, a request failing with 4xx or 5xx will print a WARN log message and the whole stacktrace.

```
17:56:01.186 [ForkJoinPool.commonPool-worker-19] WARN  o.t.l.repositories.JenkinsClient - Failed to read JSON from 'http://jenkins.terasology.io/teraorg/job/Terasology/job/Omega/job/develop/api/json?tree=builds[number,timestamp,result,artifacts[fileName,relativePath],url]'
com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:226)
        at com.google.gson.Gson.fromJson(Gson.java:932)
        at com.google.gson.Gson.fromJson(Gson.java:897)
        at com.google.gson.Gson.fromJson(Gson.java:846)
        at com.google.gson.Gson.fromJson(Gson.java:817)
        at org.terasology.launcher.repositories.JenkinsClient.request(JenkinsClient.java:72)
        at org.terasology.launcher.repositories.JenkinsRepositoryAdapter.fetchReleases(JenkinsRepositoryAdapter.java:70)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1621)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:952)
        at java.base/java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:926)
        at java.base/java.util.stream.AbstractTask.compute(AbstractTask.java:327)
        at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:746)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $
        at com.google.gson.stream.JsonReader.beginObject(JsonReader.java:386)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:215)
        ... 19 common frames omitted
```

However, further up in the code we have the `Response` object and can check for the status code before continuing processing. With this change, we only log a single WARN message now containing the status code.

```
18:09:21.834 [Launcher init thread] WARN  o.t.l.repositories.JenkinsClient - Failed to read from URL 'http://jenkins.terasology.io/teraorg/job/Terasology/job/Omega/job/develop/api/json?tree=builds[number,timestamp,result,artifacts[fileName,relativePath],url]' with status code 404.
```

### How to test

Start the launcher and observe the logs (I believe the integration with Jenkins is currently broken, so this is a "good" way to test it 🙈 )

### Outstanding before merging

Nothing.